### PR TITLE
Increase code coverage of all code in tests

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   format:
     name: Format

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # openai-orgs - CLI for OpenAI Platform Management API
 
+[![codecov](https://codecov.io/gh/klauern/openai-orgs/graph/badge.svg?token=7ENEG01SSU)](https://codecov.io/gh/klauern/openai-orgs)
+
 `openai-orgs` is a command-line interface (CLI) tool for interacting with the OpenAI Platform Administration APIs. It provides various commands to manage projects, users, API keys, service accounts, invites, and more.
 
 ## Installation
@@ -14,7 +16,7 @@ go install github.com/klauern/openai-orgs/cmd/openai-orgs@latest
 
 Before using `openai-orgs`, you need to set up your OpenAI API key:
 
-1. Log in to your OpenAI account at https://platform.openai.com/
+1. Log in to your OpenAI account at <https://platform.openai.com/>
 2. Navigate to the API keys section
 3. Create a new API key
 4. Set the API key as an environment variable:

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1,6 +1,7 @@
 package openaiorgs
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -19,6 +20,7 @@ func TestClient_Get_WithPagination(t *testing.T) {
 		LastID:  "obj2",
 		HasMore: true,
 	}
+
 	h.mockResponse("GET", "/test-endpoint", http.StatusOK, firstPageResponse)
 
 	// Mock second page response

--- a/api_client_test.go
+++ b/api_client_test.go
@@ -1,83 +1,8 @@
 package openaiorgs
 
 import (
-	"net/http"
 	"testing"
-
-	"github.com/jarcoal/httpmock"
 )
-
-const testBaseURL = "https://api.openai.com/v1"
-
-type testHelper struct {
-	client *Client
-	t      *testing.T
-}
-
-// newTestHelper creates a new test helper with mocked HTTP client
-func newTestHelper(t *testing.T) *testHelper {
-	client := NewClient(testBaseURL, "test-token")
-	// Enable HTTP mocking
-	httpmock.ActivateNonDefault(client.client.GetClient())
-
-	return &testHelper{
-		client: client,
-		t:      t,
-	}
-}
-
-// mockResponse registers a mock response for a given method, endpoint, and response
-func (h *testHelper) mockResponse(method, endpoint string, statusCode int, response interface{}) {
-	responder := func(req *http.Request) (*http.Response, error) {
-		// Return the response directly without any conditions
-		resp, err := httpmock.NewJsonResponse(statusCode, response)
-		if err != nil {
-			h.t.Fatalf("Failed to create mock response: %v", err)
-		}
-		return resp, nil
-	}
-
-	// Register the mock responder
-	httpmock.RegisterResponder(method, testBaseURL+endpoint, responder)
-}
-
-// mockListResponse is a helper for mocking paginated list responses
-func (h *testHelper) mockListResponse(method, endpoint string, items interface{}) { //nolint:unused
-	response := ListResponse[interface{}]{
-		Object:  "list",
-		Data:    []interface{}{items},
-		FirstID: "first_id",
-		LastID:  "last_id",
-		HasMore: false,
-	}
-	h.mockResponse(method, endpoint, http.StatusOK, response)
-}
-
-// cleanup removes all registered mocks
-func (h *testHelper) cleanup() {
-	httpmock.Reset()
-}
-
-// assertRequest verifies that a specific request was made
-func (h *testHelper) assertRequest(method, endpoint string, times int) {
-	// Original code only checks exact endpoint match
-	count := httpmock.GetCallCountInfo()[method+" "+testBaseURL+endpoint]
-
-	// Need to also check for endpoint with query parameters
-	if times > count {
-		// Check if there are any calls with additional query parameters
-		for key := range httpmock.GetCallCountInfo() {
-			if key != method+" "+testBaseURL+endpoint &&
-				key[:len(method+" "+testBaseURL+endpoint)] == method+" "+testBaseURL+endpoint {
-				count += httpmock.GetCallCountInfo()[key]
-			}
-		}
-	}
-
-	if count != times {
-		h.t.Errorf("Expected %d calls to %s %s, got %d", times, method, endpoint, count)
-	}
-}
 
 func TestClient_Get_WithPagination(t *testing.T) {
 	h := newTestHelper(t)

--- a/audit_logs_test.go
+++ b/audit_logs_test.go
@@ -1,0 +1,86 @@
+package openaiorgs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestListAuditLogs(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	// Mock response data
+	now := time.Now()
+	mockAuditLogs := []AuditLog{
+		{
+			ID:        "log_123",
+			Type:      "access_policy.created",
+			Timestamp: now,
+			Version:   "1.0",
+			Actor:     Actor{ID: "actor_123", Name: "Test Actor", Type: "user"},
+			Event:     Event{ID: "event_123", Type: "access_policy", Action: "created", Auth: Auth{Type: "token", Transport: "http"}},
+		},
+	}
+
+	// Register mock response
+	response := ListResponse[AuditLog]{
+		Object:  "list",
+		Data:    mockAuditLogs,
+		FirstID: "log_123",
+		LastID:  "log_123",
+		HasMore: false,
+	}
+	h.mockResponse("GET", AuditLogsListEndpoint, 200, response)
+
+	// Make the API call
+	auditLogs, err := h.client.ListAuditLogs(&AuditLogListParams{})
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+	if len(auditLogs.Data) != 1 {
+		t.Errorf("Expected 1 audit log, got %d", len(auditLogs.Data))
+		return
+	}
+	if mockAuditLogs[0].ID != auditLogs.Data[0].ID {
+		t.Errorf("Expected ID %s, got %s", mockAuditLogs[0].ID, auditLogs.Data[0].ID)
+	}
+	if mockAuditLogs[0].Type != auditLogs.Data[0].Type {
+		t.Errorf("Expected Type %s, got %s", mockAuditLogs[0].Type, auditLogs.Data[0].Type)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", AuditLogsListEndpoint, 1)
+}
+
+func TestParseAuditLogPayload(t *testing.T) {
+	auditLog := &AuditLog{
+		Type: "access_policy.created",
+		Event: Event{
+			Payload: map[string]interface{}{
+				"id":   "policy_123",
+				"name": "Test Policy",
+			},
+		},
+	}
+
+	payload, err := ParseAuditLogPayload(auditLog)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+
+	accessPolicyCreated, ok := payload.(*AccessPolicyCreated)
+	if !ok {
+		t.Errorf("Expected payload to be of type *AccessPolicyCreated, got %T", payload)
+		return
+	}
+
+	if accessPolicyCreated.ID != "policy_123" {
+		t.Errorf("Expected ID %s, got %s", "policy_123", accessPolicyCreated.ID)
+	}
+	if accessPolicyCreated.Name != "Test Policy" {
+		t.Errorf("Expected Name %s, got %s", "Test Policy", accessPolicyCreated.Name)
+	}
+}

--- a/project_api_keys.go
+++ b/project_api_keys.go
@@ -18,7 +18,7 @@ type Owner struct {
 	ID     string                 `json:"id"`
 	Name   string                 `json:"name"`
 	Type   OwnerType              `json:"type"`
-	User   *Users                 `json:"user,omitempty"`
+	User   *User                  `json:"user,omitempty"`
 	SA     *ProjectServiceAccount `json:"service_account,omitempty"`
 }
 

--- a/project_api_keys_test.go
+++ b/project_api_keys_test.go
@@ -1,0 +1,117 @@
+package openaiorgs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestListProjectApiKeys(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	// Mock response data
+	now := time.Now()
+	mockApiKeys := []ProjectApiKey{
+		{
+			Object:        "api_key",
+			ID:            "key_123",
+			Name:          "Test API Key",
+			RedactedValue: "sk-****",
+			CreatedAt:     UnixSeconds(now),
+			Owner: Owner{
+				Object: "user",
+				ID:     "user_123",
+				Name:   "Test User",
+				Type:   OwnerTypeUser,
+			},
+		},
+	}
+
+	// Register mock response
+	response := ListResponse[ProjectApiKey]{
+		Object:  "list",
+		Data:    mockApiKeys,
+		FirstID: "key_123",
+		LastID:  "key_123",
+		HasMore: false,
+	}
+	h.mockResponse("GET", "/organization/projects/proj_123/api_keys", 200, response)
+
+	// Make the API call
+	apiKeys, err := h.client.ListProjectApiKeys("proj_123", 10, "")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+	if len(apiKeys.Data) != 1 {
+		t.Errorf("Expected 1 API key, got %d", len(apiKeys.Data))
+		return
+	}
+	if mockApiKeys[0].ID != apiKeys.Data[0].ID {
+		t.Errorf("Expected ID %s, got %s", mockApiKeys[0].ID, apiKeys.Data[0].ID)
+	}
+	if mockApiKeys[0].Name != apiKeys.Data[0].Name {
+		t.Errorf("Expected Name %s, got %s", mockApiKeys[0].Name, apiKeys.Data[0].Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/api_keys", 1)
+}
+
+func TestRetrieveProjectApiKey(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	apiKeyID := "key_123"
+	mockApiKey := ProjectApiKey{
+		Object:        "api_key",
+		ID:            apiKeyID,
+		Name:          "Test API Key",
+		RedactedValue: "sk-****",
+		CreatedAt:     UnixSeconds(time.Now()),
+		Owner: Owner{
+			Object: "user",
+			ID:     "user_123",
+			Name:   "Test User",
+			Type:   OwnerTypeUser,
+		},
+	}
+
+	h.mockResponse("GET", "/organization/projects/proj_123/api_keys/"+apiKeyID, 200, mockApiKey)
+
+	// Make the API call
+	apiKey, err := h.client.RetrieveProjectApiKey("proj_123", apiKeyID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if apiKey == nil {
+		t.Error("Expected API key, got nil")
+		return
+	}
+	if mockApiKey.ID != apiKey.ID {
+		t.Errorf("Expected ID %s, got %s", mockApiKey.ID, apiKey.ID)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/api_keys/"+apiKeyID, 1)
+}
+
+func TestDeleteProjectApiKey(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	apiKeyID := "key_123"
+	h.mockResponse("DELETE", "/organization/projects/proj_123/api_keys/"+apiKeyID, 204, nil)
+
+	// Make the API call
+	err := h.client.DeleteProjectApiKey("proj_123", apiKeyID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Verify the request was made
+	h.assertRequest("DELETE", "/organization/projects/proj_123/api_keys/"+apiKeyID, 1)
+}

--- a/project_service_accounts_test.go
+++ b/project_service_accounts_test.go
@@ -1,0 +1,140 @@
+package openaiorgs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestListProjectServiceAccounts(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	// Mock response data
+	now := time.Now()
+	mockAccounts := []ProjectServiceAccount{
+		{
+			Object:    "project_service_account",
+			ID:        "service_account_123",
+			Name:      "Test Service Account",
+			Role:      "admin",
+			CreatedAt: UnixSeconds(now),
+		},
+	}
+
+	// Register mock response
+	response := ListResponse[ProjectServiceAccount]{
+		Object:  "list",
+		Data:    mockAccounts,
+		FirstID: "service_account_123",
+		LastID:  "service_account_123",
+		HasMore: false,
+	}
+	h.mockResponse("GET", "/organization/projects/proj_123/service_accounts", 200, response)
+
+	// Make the API call
+	accounts, err := h.client.ListProjectServiceAccounts("proj_123", 10, "")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+	if len(accounts.Data) != 1 {
+		t.Errorf("Expected 1 service account, got %d", len(accounts.Data))
+		return
+	}
+	if mockAccounts[0].ID != accounts.Data[0].ID {
+		t.Errorf("Expected ID %s, got %s", mockAccounts[0].ID, accounts.Data[0].ID)
+	}
+	if mockAccounts[0].Name != accounts.Data[0].Name {
+		t.Errorf("Expected Name %s, got %s", mockAccounts[0].Name, accounts.Data[0].Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/service_accounts", 1)
+}
+
+func TestCreateProjectServiceAccount(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	mockAccount := ProjectServiceAccount{
+		Object:    "project_service_account",
+		ID:        "service_account_123",
+		Name:      "New Service Account",
+		Role:      "admin",
+		CreatedAt: UnixSeconds(time.Now()),
+	}
+
+	h.mockResponse("POST", "/organization/projects/proj_123/service_accounts", 200, mockAccount)
+
+	// Make the API call
+	account, err := h.client.CreateProjectServiceAccount("proj_123", "New Service Account")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if account == nil {
+		t.Error("Expected service account, got nil")
+		return
+	}
+	if mockAccount.ID != account.ID {
+		t.Errorf("Expected ID %s, got %s", mockAccount.ID, account.ID)
+	}
+	if mockAccount.Name != account.Name {
+		t.Errorf("Expected Name %s, got %s", mockAccount.Name, account.Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", "/organization/projects/proj_123/service_accounts", 1)
+}
+
+func TestRetrieveProjectServiceAccount(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	accountID := "service_account_123"
+	mockAccount := ProjectServiceAccount{
+		Object:    "project_service_account",
+		ID:        accountID,
+		Name:      "Test Service Account",
+		Role:      "admin",
+		CreatedAt: UnixSeconds(time.Now()),
+	}
+
+	h.mockResponse("GET", "/organization/projects/proj_123/service_accounts/"+accountID, 200, mockAccount)
+
+	// Make the API call
+	account, err := h.client.RetrieveProjectServiceAccount("proj_123", accountID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if account == nil {
+		t.Error("Expected service account, got nil")
+		return
+	}
+	if mockAccount.ID != account.ID {
+		t.Errorf("Expected ID %s, got %s", mockAccount.ID, account.ID)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/service_accounts/"+accountID, 1)
+}
+
+func TestDeleteProjectServiceAccount(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	accountID := "service_account_123"
+	h.mockResponse("DELETE", "/organization/projects/proj_123/service_accounts/"+accountID, 204, nil)
+
+	// Make the API call
+	err := h.client.DeleteProjectServiceAccount("proj_123", accountID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Verify the request was made
+	h.assertRequest("DELETE", "/organization/projects/proj_123/service_accounts/"+accountID, 1)
+}

--- a/project_users_test.go
+++ b/project_users_test.go
@@ -1,0 +1,180 @@
+package openaiorgs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestListProjectUsers(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	// Mock response data
+	now := time.Now()
+	mockUsers := []ProjectUser{
+		{
+			Object:  "project_user",
+			ID:      "user_123",
+			Name:    "Test User",
+			Email:   "test@example.com",
+			Role:    "member",
+			AddedAt: UnixSeconds(now),
+		},
+	}
+
+	// Register mock response
+	response := ListResponse[ProjectUser]{
+		Object:  "list",
+		Data:    mockUsers,
+		FirstID: "user_123",
+		LastID:  "user_123",
+		HasMore: false,
+	}
+	h.mockResponse("GET", "/organization/projects/proj_123/users", 200, response)
+
+	// Make the API call
+	users, err := h.client.ListProjectUsers("proj_123", 10, "")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+	if len(users.Data) != 1 {
+		t.Errorf("Expected 1 user, got %d", len(users.Data))
+		return
+	}
+	if mockUsers[0].ID != users.Data[0].ID {
+		t.Errorf("Expected ID %s, got %s", mockUsers[0].ID, users.Data[0].ID)
+	}
+	if mockUsers[0].Name != users.Data[0].Name {
+		t.Errorf("Expected Name %s, got %s", mockUsers[0].Name, users.Data[0].Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/users", 1)
+}
+
+func TestCreateProjectUser(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	mockUser := ProjectUser{
+		Object:  "project_user",
+		ID:      "user_123",
+		Name:    "New User",
+		Email:   "new@example.com",
+		Role:    "member",
+		AddedAt: UnixSeconds(time.Now()),
+	}
+
+	h.mockResponse("POST", "/organization/projects/proj_123/users", 200, mockUser)
+
+	// Make the API call
+	user, err := h.client.CreateProjectUser("proj_123", "user_123", "member")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if user == nil {
+		t.Error("Expected user, got nil")
+		return
+	}
+	if mockUser.ID != user.ID {
+		t.Errorf("Expected ID %s, got %s", mockUser.ID, user.ID)
+	}
+	if mockUser.Name != user.Name {
+		t.Errorf("Expected Name %s, got %s", mockUser.Name, user.Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", "/organization/projects/proj_123/users", 1)
+}
+
+func TestRetrieveProjectUser(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	userID := "user_123"
+	mockUser := ProjectUser{
+		Object:  "project_user",
+		ID:      userID,
+		Name:    "Test User",
+		Email:   "test@example.com",
+		Role:    "member",
+		AddedAt: UnixSeconds(time.Now()),
+	}
+
+	h.mockResponse("GET", "/organization/projects/proj_123/users/"+userID, 200, mockUser)
+
+	// Make the API call
+	user, err := h.client.RetrieveProjectUser("proj_123", userID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if user == nil {
+		t.Error("Expected user, got nil")
+		return
+	}
+	if mockUser.ID != user.ID {
+		t.Errorf("Expected ID %s, got %s", mockUser.ID, user.ID)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", "/organization/projects/proj_123/users/"+userID, 1)
+}
+
+func TestModifyProjectUser(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	userID := "user_123"
+	mockUser := ProjectUser{
+		Object:  "project_user",
+		ID:      userID,
+		Name:    "Test User",
+		Email:   "test@example.com",
+		Role:    "owner",
+		AddedAt: UnixSeconds(time.Now()),
+	}
+
+	h.mockResponse("POST", "/organization/projects/proj_123/users/"+userID, 200, mockUser)
+
+	// Make the API call
+	user, err := h.client.ModifyProjectUser("proj_123", userID, "owner")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if user == nil {
+		t.Error("Expected user, got nil")
+		return
+	}
+	if mockUser.ID != user.ID {
+		t.Errorf("Expected ID %s, got %s", mockUser.ID, user.ID)
+	}
+	if mockUser.Role != user.Role {
+		t.Errorf("Expected Role %s, got %s", mockUser.Role, user.Role)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", "/organization/projects/proj_123/users/"+userID, 1)
+}
+
+func TestDeleteProjectUser(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	userID := "user_123"
+	h.mockResponse("DELETE", "/organization/projects/proj_123/users/"+userID, 204, nil)
+
+	// Make the API call
+	err := h.client.DeleteProjectUser("proj_123", userID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Verify the request was made
+	h.assertRequest("DELETE", "/organization/projects/proj_123/users/"+userID, 1)
+}

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,0 +1,194 @@
+package openaiorgs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestListProjects(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	// Mock response data
+	now := time.Now()
+	mockProjects := []Project{
+		{
+			Object:    "project",
+			ID:        "proj_123",
+			Name:      "Test Project",
+			CreatedAt: UnixSeconds(now),
+			Status:    "active",
+		},
+	}
+
+	// Register mock response
+	response := ListResponse[Project]{
+		Object:  "list",
+		Data:    mockProjects,
+		FirstID: "proj_123",
+		LastID:  "proj_123",
+		HasMore: false,
+	}
+	h.mockResponse("GET", ProjectsListEndpoint, 200, response)
+
+	// Make the API call
+	projects, err := h.client.ListProjects(10, "", false)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+		return
+	}
+	if len(projects.Data) != 1 {
+		t.Errorf("Expected 1 project, got %d", len(projects.Data))
+		return
+	}
+	if mockProjects[0].ID != projects.Data[0].ID {
+		t.Errorf("Expected ID %s, got %s", mockProjects[0].ID, projects.Data[0].ID)
+	}
+	if mockProjects[0].Name != projects.Data[0].Name {
+		t.Errorf("Expected Name %s, got %s", mockProjects[0].Name, projects.Data[0].Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", ProjectsListEndpoint, 1)
+}
+
+func TestCreateProject(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	mockProject := Project{
+		Object:    "project",
+		ID:        "proj_123",
+		Name:      "New Project",
+		CreatedAt: UnixSeconds(time.Now()),
+		Status:    "active",
+	}
+
+	h.mockResponse("POST", ProjectsListEndpoint, 200, mockProject)
+
+	// Make the API call
+	project, err := h.client.CreateProject("New Project")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Error("Expected project, got nil")
+		return
+	}
+	if mockProject.ID != project.ID {
+		t.Errorf("Expected ID %s, got %s", mockProject.ID, project.ID)
+	}
+	if mockProject.Name != project.Name {
+		t.Errorf("Expected Name %s, got %s", mockProject.Name, project.Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", ProjectsListEndpoint, 1)
+}
+
+func TestRetrieveProject(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	projectID := "proj_123"
+	mockProject := Project{
+		Object:    "project",
+		ID:        projectID,
+		Name:      "Test Project",
+		CreatedAt: UnixSeconds(time.Now()),
+		Status:    "active",
+	}
+
+	h.mockResponse("GET", ProjectsListEndpoint+"/"+projectID, 200, mockProject)
+
+	// Make the API call
+	project, err := h.client.RetrieveProject(projectID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Error("Expected project, got nil")
+		return
+	}
+	if mockProject.ID != project.ID {
+		t.Errorf("Expected ID %s, got %s", mockProject.ID, project.ID)
+	}
+
+	// Verify the request was made
+	h.assertRequest("GET", ProjectsListEndpoint+"/"+projectID, 1)
+}
+
+func TestModifyProject(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	projectID := "proj_123"
+	mockProject := Project{
+		Object:    "project",
+		ID:        projectID,
+		Name:      "Updated Project",
+		CreatedAt: UnixSeconds(time.Now()),
+		Status:    "active",
+	}
+
+	h.mockResponse("POST", ProjectsListEndpoint+"/"+projectID, 200, mockProject)
+
+	// Make the API call
+	project, err := h.client.ModifyProject(projectID, "Updated Project")
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Error("Expected project, got nil")
+		return
+	}
+	if mockProject.ID != project.ID {
+		t.Errorf("Expected ID %s, got %s", mockProject.ID, project.ID)
+	}
+	if mockProject.Name != project.Name {
+		t.Errorf("Expected Name %s, got %s", mockProject.Name, project.Name)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", ProjectsListEndpoint+"/"+projectID, 1)
+}
+
+func TestArchiveProject(t *testing.T) {
+	h := newTestHelper(t)
+	defer h.cleanup()
+
+	projectID := "proj_123"
+	mockProject := Project{
+		Object:    "project",
+		ID:        projectID,
+		Name:      "Test Project",
+		CreatedAt: UnixSeconds(time.Now()),
+		Status:    "archived",
+	}
+
+	h.mockResponse("POST", ProjectsListEndpoint+"/"+projectID+"/archive", 200, mockProject)
+
+	// Make the API call
+	project, err := h.client.ArchiveProject(projectID)
+	// Assert results
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Error("Expected project, got nil")
+		return
+	}
+	if mockProject.ID != project.ID {
+		t.Errorf("Expected ID %s, got %s", mockProject.ID, project.ID)
+	}
+	if mockProject.Status != project.Status {
+		t.Errorf("Expected Status %s, got %s", mockProject.Status, project.Status)
+	}
+
+	// Verify the request was made
+	h.assertRequest("POST", ProjectsListEndpoint+"/"+projectID+"/archive", 1)
+}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -1,0 +1,80 @@
+package openaiorgs
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+const testBaseURL = "https://api.openai.com/v1"
+
+type testHelper struct {
+	client *Client
+	t      *testing.T
+}
+
+// newTestHelper creates a new test helper with mocked HTTP client
+func newTestHelper(t *testing.T) *testHelper {
+	client := NewClient(testBaseURL, "test-token")
+	// Enable HTTP mocking
+	httpmock.ActivateNonDefault(client.client.GetClient())
+
+	return &testHelper{
+		client: client,
+		t:      t,
+	}
+}
+
+// mockResponse registers a mock response for a given method, endpoint, and response
+func (h *testHelper) mockResponse(method, endpoint string, statusCode int, response interface{}) {
+	responder := func(req *http.Request) (*http.Response, error) {
+		// Return the response directly without any conditions
+		resp, err := httpmock.NewJsonResponse(statusCode, response)
+		if err != nil {
+			h.t.Fatalf("Failed to create mock response: %v", err)
+		}
+		return resp, nil
+	}
+
+	// Register the mock responder
+	httpmock.RegisterResponder(method, testBaseURL+endpoint, responder)
+}
+
+// mockListResponse is a helper for mocking paginated list responses
+func (h *testHelper) mockListResponse(method, endpoint string, items interface{}) {
+	response := ListResponse[interface{}]{
+		Object:  "list",
+		Data:    []interface{}{items},
+		FirstID: "first_id",
+		LastID:  "last_id",
+		HasMore: false,
+	}
+	h.mockResponse(method, endpoint, http.StatusOK, response)
+}
+
+// cleanup removes all registered mocks
+func (h *testHelper) cleanup() {
+	httpmock.Reset()
+}
+
+// assertRequest verifies that a specific request was made
+func (h *testHelper) assertRequest(method, endpoint string, times int) {
+	// Original code only checks exact endpoint match
+	count := httpmock.GetCallCountInfo()[method+" "+testBaseURL+endpoint]
+
+	// Need to also check for endpoint with query parameters
+	if times > count {
+		// Check if there are any calls with additional query parameters
+		for key := range httpmock.GetCallCountInfo() {
+			if key != method+" "+testBaseURL+endpoint &&
+				key[:len(method+" "+testBaseURL+endpoint)] == method+" "+testBaseURL+endpoint {
+				count += httpmock.GetCallCountInfo()[key]
+			}
+		}
+	}
+
+	if count != times {
+		h.t.Errorf("Expected %d calls to %s %s, got %d", times, method, endpoint, count)
+	}
+}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -42,7 +42,7 @@ func (h *testHelper) mockResponse(method, endpoint string, statusCode int, respo
 }
 
 // mockListResponse is a helper for mocking paginated list responses
-func (h *testHelper) mockListResponse(method, endpoint string, items interface{}) {
+func (h *testHelper) mockListResponse(method, endpoint string, items interface{}) { //nolint:unused
 	response := ListResponse[interface{}]{
 		Object:  "list",
 		Data:    []interface{}{items},

--- a/users.go
+++ b/users.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// Users represents a user in the OpenAI organization
-type Users struct {
+// User represents a user in the OpenAI organization
+type User struct {
 	Object  string      `json:"object"`
 	ID      string      `json:"id"`
 	Name    string      `json:"name"`
@@ -16,7 +16,7 @@ type Users struct {
 
 const UsersListEndpoint = "/organization/users"
 
-func (c *Client) ListUsers(limit int, after string) (*ListResponse[Users], error) {
+func (c *Client) ListUsers(limit int, after string) (*ListResponse[User], error) {
 	queryParams := make(map[string]string)
 	if limit > 0 {
 		queryParams["limit"] = fmt.Sprintf("%d", limit)
@@ -25,15 +25,15 @@ func (c *Client) ListUsers(limit int, after string) (*ListResponse[Users], error
 		queryParams["after"] = after
 	}
 
-	return Get[Users](c.client, UsersListEndpoint, queryParams)
+	return Get[User](c.client, UsersListEndpoint, queryParams)
 }
 
-func (c *Client) RetrieveUser(id string) (*Users, error) {
-	return GetSingle[Users](c.client, UsersListEndpoint+"/"+id)
+func (c *Client) RetrieveUser(id string) (*User, error) {
+	return GetSingle[User](c.client, UsersListEndpoint+"/"+id)
 }
 
 func (c *Client) DeleteUser(id string) error {
-	err := Delete[Users](c.client, UsersListEndpoint+"/"+id)
+	err := Delete[User](c.client, UsersListEndpoint+"/"+id)
 	if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
@@ -46,7 +46,7 @@ func (c *Client) ModifyUserRole(id string, role RoleType) error {
 		"role": string(role),
 	}
 
-	_, err := Post[Users](c.client, UsersListEndpoint+"/"+id, body)
+	_, err := Post[User](c.client, UsersListEndpoint+"/"+id, body)
 	if err != nil {
 		return fmt.Errorf("failed to modify user role: %w", err)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -1,0 +1,201 @@
+package openaiorgs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestListUsers(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockResponse     ListResponse[User]
+		mockResponseCode int
+		expectedError    error
+		expectedLength   int
+	}{
+		{
+			name: "Valid response",
+			mockResponse: ListResponse[User]{
+				Object:  "list",
+				Data:    []User{{ID: "user_123", Name: "Test User"}},
+				FirstID: "user_123",
+				LastID:  "user_123",
+				HasMore: false,
+			},
+			mockResponseCode: 200,
+			expectedError:    nil,
+			expectedLength:   1,
+		},
+		// error response
+		{
+			name:             "Error response",
+			mockResponse:     ListResponse[User]{},
+			mockResponseCode: 400,
+			expectedError:    fmt.Errorf("API request failed with status code 400: {\"object\":\"\",\"data\":null,\"first_id\":\"\",\"last_id\":\"\",\"has_more\":false}"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHelper(t)
+			defer h.cleanup()
+
+			h.mockResponse("GET", "/organization/users", tt.mockResponseCode, tt.mockResponse)
+
+			users, err := h.client.ListUsers(10, "")
+			if err != nil && err.Error() != tt.expectedError.Error() {
+				t.Errorf("Expected error %v, got %v", tt.expectedError, err)
+			}
+			if err == nil && tt.expectedError != nil {
+				t.Errorf("Expected error %v, got nil", tt.expectedError)
+			} else if err == nil {
+				if len(users.Data) != tt.expectedLength {
+					t.Errorf("Expected %d users, got %d", tt.expectedLength, len(users.Data))
+				}
+			}
+
+			h.assertRequest("GET", "/organization/users", 1)
+		})
+	}
+}
+
+func TestRetrieveUser(t *testing.T) {
+	tests := []struct {
+		name             string
+		userID           string
+		mockUser         User
+		mockResponseCode int
+		expectedError    error
+	}{
+		{
+			name:   "Valid user",
+			userID: "user_123",
+			mockUser: User{
+				ID:   "user_123",
+				Name: "Test User",
+			},
+			mockResponseCode: 200,
+			expectedError:    nil,
+		},
+		// error response
+		{
+			name:             "Error response",
+			userID:           "user_123",
+			mockResponseCode: 400,
+			expectedError:    fmt.Errorf("API request failed with status code 400: {\"object\":\"\",\"id\":\"\",\"name\":\"\",\"email\":\"\",\"role\":\"\",\"added_at\":-62135596800}"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHelper(t)
+			defer h.cleanup()
+
+			h.mockResponse("GET", "/organization/users/"+tt.userID, tt.mockResponseCode, tt.mockUser)
+
+			user, err := h.client.RetrieveUser(tt.userID)
+			if err != nil && err.Error() != tt.expectedError.Error() {
+				t.Errorf("Expected error %v, got %v", tt.expectedError, err)
+			}
+			if err == nil && tt.expectedError != nil {
+				t.Errorf("Expected error %v, got nil", tt.expectedError)
+			} else if err == nil {
+				if user == nil {
+					t.Error("Expected user, got nil")
+				}
+				if tt.mockUser.ID != user.ID {
+					t.Errorf("Expected ID %s, got %s", tt.mockUser.ID, user.ID)
+				}
+			}
+
+			h.assertRequest("GET", "/organization/users/"+tt.userID, 1)
+		})
+	}
+}
+
+func TestModifyUser(t *testing.T) {
+	tests := []struct {
+		name             string
+		userID           string
+		newRole          string
+		expectedError    error
+		mockResponseCode int
+	}{
+		{
+			name:             "Valid modification",
+			userID:           "user_123",
+			newRole:          "owner",
+			expectedError:    nil,
+			mockResponseCode: 200,
+		},
+		// error response
+		{
+			name:             "Error response",
+			userID:           "user_123",
+			newRole:          "owner",
+			expectedError:    fmt.Errorf("failed to modify user role: API request failed with status code 400: null"),
+			mockResponseCode: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHelper(t)
+			defer h.cleanup()
+
+			h.mockResponse("POST", "/organization/users/"+tt.userID, tt.mockResponseCode, nil)
+
+			err := h.client.ModifyUserRole(tt.userID, ParseRoleType(tt.newRole))
+			if err != nil && err.Error() != tt.expectedError.Error() {
+				t.Errorf("Expected error %v, got %v", tt.expectedError, err)
+			}
+			if err == nil && tt.expectedError != nil {
+				t.Errorf("Expected error %v, got nil", tt.expectedError)
+			}
+
+			h.assertRequest("POST", "/organization/users/"+tt.userID, 1)
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	tests := []struct {
+		name             string
+		userID           string
+		mockResponseCode int
+		expectedError    error
+	}{
+		{
+			name:             "Valid deletion",
+			userID:           "user_123",
+			mockResponseCode: 204,
+			expectedError:    nil,
+		},
+		// error response
+		{
+			name:             "Error response",
+			userID:           "user_123",
+			mockResponseCode: 400,
+			expectedError:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHelper(t)
+			defer h.cleanup()
+
+			h.mockResponse("DELETE", "/organization/users/"+tt.userID, tt.mockResponseCode, nil)
+
+			err := h.client.DeleteUser(tt.userID)
+			if err != nil && err.Error() != tt.expectedError.Error() {
+				t.Errorf("Expected error %v, got %v", tt.expectedError, err)
+			}
+			if err == nil && tt.expectedError != nil {
+				t.Errorf("Expected error %v, got nil", tt.expectedError)
+			}
+
+			h.assertRequest("DELETE", "/organization/users/"+tt.userID, 1)
+		})
+	}
+}

--- a/users_test.go
+++ b/users_test.go
@@ -102,8 +102,7 @@ func TestRetrieveUser(t *testing.T) {
 			} else if err == nil {
 				if user == nil {
 					t.Error("Expected user, got nil")
-				}
-				if tt.mockUser.ID != user.ID {
+				} else if tt.mockUser.ID != user.ID {
 					t.Errorf("Expected ID %s, got %s", tt.mockUser.ID, user.ID)
 				}
 			}


### PR DESCRIPTION
Add a reusable mocking framework for `api_client.go` generic functions and use it across multiple test files.

* **test_helpers.go**: Add the `testHelper` struct and its methods for mocking and asserting requests.
* **projects_test.go**: Add tests for listing, creating, retrieving, modifying, and archiving projects using the reusable mocking framework.
* **project_users_test.go**: Add tests for listing, creating, retrieving, modifying, and deleting project users using the reusable mocking framework.
* **project_service_accounts_test.go**: Add tests for listing, creating, retrieving, and deleting project service accounts using the reusable mocking framework.
* **project_api_keys_test.go**: Add tests for listing, retrieving, and deleting project API keys using the reusable mocking framework.
* **audit_logs_test.go**: Add tests for listing audit logs and parsing audit log payloads using the reusable mocking framework.
* **api_client_test.go**: Remove the `testHelper` struct and its methods, and use the reusable mocking framework from `test_helpers.go`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/klauern/openai-orgs?shareId=7f846784-4dbd-4636-9f04-b0594b0146af).