### PR TITLE
Fix type requirement for organization invites

### DIFF
--- a/cmd/org_invites.go
+++ b/cmd/org_invites.go
@@ -112,9 +112,8 @@ func createInvite(c *cli.Context) error {
 	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, c.String("api-key"))
 
 	email := c.String("email")
-	role := openaiorgs.RoleType(c.String("role"))
 
-	invite, err := client.CreateInvite(email, role)
+	invite, err := client.CreateInvite(email, c.String("role"))
 	if err != nil {
 		return fmt.Errorf("failed to create invite: %w", err)
 	}

--- a/invites.go
+++ b/invites.go
@@ -26,10 +26,10 @@ func (c *Client) ListInvites() ([]Invite, error) {
 	return resp.Data, nil
 }
 
-func (c *Client) CreateInvite(email string, role RoleType) (*Invite, error) {
+func (c *Client) CreateInvite(email string, role string) (*Invite, error) {
 	body := map[string]string{
 		"email": email,
-		"role":  string(role),
+		"role":  role,
 	}
 
 	invite, err := Post[Invite](c.client, InviteListEndpoint, body)

--- a/invites_test.go
+++ b/invites_test.go
@@ -72,7 +72,7 @@ func TestCreateInvite(t *testing.T) {
 	h.mockResponse("POST", InviteListEndpoint, 200, mockInvite)
 
 	// Make the API call
-	invite, err := h.client.CreateInvite("new@example.com", RoleType("admin"))
+	invite, err := h.client.CreateInvite("new@example.com", "admin")
 	// Assert results
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)


### PR DESCRIPTION
Don't require a typed parameter, just use the `string`.