### PR TITLE
feat: add api key

### DIFF
--- a/cmd/project_service_accounts.go
+++ b/cmd/project_service_accounts.go
@@ -142,11 +142,12 @@ func createProjectServiceAccount(c *cli.Context) error {
 	}
 
 	fmt.Printf("Project service account created:\n")
-	fmt.Printf("ID: %s\nName: %s\nRole: %s\nCreated At: %s\n",
+	fmt.Printf("ID: %s\nName: %s\nRole: %s\nCreated At: %s\nAPI Key: %s\n",
 		account.ID,
 		account.Name,
 		account.Role,
 		account.CreatedAt.String(),
+		account.APIKey.Value,
 	)
 
 	return nil

--- a/project_service_accounts.go
+++ b/project_service_accounts.go
@@ -5,11 +5,20 @@ import "fmt"
 const ProjectServiceAccountsListEndpoint = "/organization/projects/%s/service_accounts"
 
 type ProjectServiceAccount struct {
+	Object    string                       `json:"object"`
+	ID        string                       `json:"id"`
+	Name      string                       `json:"name"`
+	Role      string                       `json:"role"`
+	CreatedAt UnixSeconds                  `json:"created_at"`
+	APIKey    *ProjectServiceAccountAPIKey `json:"api_key,omitempty"`
+}
+
+type ProjectServiceAccountAPIKey struct {
 	Object    string      `json:"object"`
-	ID        string      `json:"id"`
-	Name      string      `json:"name"`
-	Role      string      `json:"role"`
+	Value     string      `json:"value"`
+	Name      *string     `json:"name"`
 	CreatedAt UnixSeconds `json:"created_at"`
+	ID        string      `json:"id"`
 }
 
 func (c *Client) ListProjectServiceAccounts(projectID string, limit int, after string) (*ListResponse[ProjectServiceAccount], error) {

--- a/project_service_accounts_test.go
+++ b/project_service_accounts_test.go
@@ -18,6 +18,7 @@ func TestListProjectServiceAccounts(t *testing.T) {
 			Name:      "Test Service Account",
 			Role:      "admin",
 			CreatedAt: UnixSeconds(now),
+			APIKey:    nil,
 		},
 	}
 
@@ -63,6 +64,13 @@ func TestCreateProjectServiceAccount(t *testing.T) {
 		Name:      "New Service Account",
 		Role:      "admin",
 		CreatedAt: UnixSeconds(time.Now()),
+		APIKey: &ProjectServiceAccountAPIKey{
+			Object:    "project_service_account_api_key",
+			Value:     "sk-api-key-123",
+			Name:      nil,
+			CreatedAt: UnixSeconds(time.Now()),
+			ID:        "api_key_123",
+		},
 	}
 
 	h.mockResponse("POST", "/organization/projects/proj_123/service_accounts", 200, mockAccount)
@@ -99,6 +107,7 @@ func TestRetrieveProjectServiceAccount(t *testing.T) {
 		Name:      "Test Service Account",
 		Role:      "admin",
 		CreatedAt: UnixSeconds(time.Now()),
+		APIKey:    nil,
 	}
 
 	h.mockResponse("GET", "/organization/projects/proj_123/service_accounts/"+accountID, 200, mockAccount)


### PR DESCRIPTION
On `Create()` you also get the API key, which wasn't being parsed out.