### PR TITLE
feat: initial commit to stub out MCP server support

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,3 +33,8 @@ tasks:
       - test
     cmds:
       - go tool cover -html=coverage.out
+
+  mcp-dev:
+    desc: Run the modelcontexprotocol inspector
+    cmds:
+      - npx @modelcontextprotocol/inspector go run cmd/mcp/main.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,4 +37,4 @@ tasks:
   mcp-dev:
     desc: Run the modelcontexprotocol inspector
     cmds:
-      - npx @modelcontextprotocol/inspector go run cmd/mcp/main.go
+      - npx @modelcontextprotocol/inspector -e OPENAI_API_KEY=$OPENAI_API_KEY go run cmd/mcp/main.go

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,6 @@ tasks:
       - go tool cover -html=coverage.out
 
   mcp-dev:
-    desc: Run the modelcontexprotocol inspector
+    desc: Run the modelcontextprotocol inspector
     cmds:
       - npx @modelcontextprotocol/inspector -e OPENAI_API_KEY=$OPENAI_API_KEY go run cmd/mcp/main.go

--- a/admin_api_keys.go
+++ b/admin_api_keys.go
@@ -1,6 +1,9 @@
 package openaiorgs
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const AdminAPIKeysEndpoint = "/organization/admin_api_keys"
 
@@ -45,4 +48,14 @@ func (c *Client) RetrieveAdminAPIKey(apiKeyID string) (*AdminAPIKey, error) {
 // DeleteAdminAPIKey deletes an organization API key
 func (c *Client) DeleteAdminAPIKey(apiKeyID string) error {
 	return Delete[AdminAPIKey](c.client, fmt.Sprintf("%s/%s", AdminAPIKeysEndpoint, apiKeyID))
+}
+
+// String returns a human-readable string representation of the AdminAPIKey
+func (ak *AdminAPIKey) String() string {
+	scopeInfo := "no scopes"
+	if len(ak.Scopes) > 0 {
+		scopeInfo = fmt.Sprintf("scopes:%s", strings.Join(ak.Scopes, ","))
+	}
+	return fmt.Sprintf("AdminAPIKey{ID: %s, Name: %s, %s}",
+		ak.ID, ak.Name, scopeInfo)
 }

--- a/audit_logs.go
+++ b/audit_logs.go
@@ -354,3 +354,22 @@ func (c *Client) ListAuditLogs(params *AuditLogListParams) (*ListResponse[AuditL
 
 	return Get[AuditLog](c.client, AuditLogsListEndpoint, queryParams)
 }
+
+// String returns a human-readable string representation of the AuditLog
+func (al *AuditLog) String() string {
+	projectInfo := "no project"
+	if al.Project != nil {
+		projectInfo = fmt.Sprintf("%s(%s)", al.Project.Name, al.Project.ID)
+	}
+
+	actorInfo := "unknown"
+	switch {
+	case al.Actor.Session != nil:
+		actorInfo = fmt.Sprintf("user:%s", al.Actor.Session.User.Email)
+	case al.Actor.APIKey != nil:
+		actorInfo = fmt.Sprintf("apikey:%s", al.Actor.APIKey.User.Email)
+	}
+
+	return fmt.Sprintf("AuditLog{ID: %s, Type: %s, Project: %s, Actor: %s, Time: %s}",
+		al.ID, al.Type, projectInfo, actorInfo, al.EffectiveAt.String())
+}

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -1,27 +1,17 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"log"
 
-	"github.com/klauern/openai-orgs/internal/mcp"
+	"github.com/klauern/openai-orgs/pkg/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
 func main() {
-	cfg := mcp.ServerConfig{
-		Name:    "OpenAI Orgs MCP Server",
-		Version: "1.0.0",
-	}
+	mcpServer := mcp.NewMCPServer()
 
-	s, err := mcp.NewServer(cfg)
+	err := server.ServeStdio(mcpServer, server.WithStdioContextFunc(mcp.AuthFromEnvironment))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating server: %v\n", err)
-		os.Exit(1)
-	}
-
-	if err := server.ServeStdio(s); err != nil {
-		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("Error serving server: %v", err)
 	}
 }

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/klauern/openai-orgs/internal/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func main() {
+	cfg := mcp.ServerConfig{
+		Name:    "OpenAI Orgs MCP Server",
+		Version: "1.0.0",
+	}
+
+	s, err := mcp.NewServer(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating server: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := server.ServeStdio(s); err != nil {
+		fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/project_api_keys.go
+++ b/cmd/project_api_keys.go
@@ -14,7 +14,6 @@ func ProjectAPIKeysCommand() *cli.Command {
 		Usage: "Manage project API keys",
 		Commands: []*cli.Command{
 			listProjectAPIKeysCommand(),
-			createProjectAPIKeyCommand(),
 			retrieveProjectAPIKeyCommand(),
 			deleteProjectAPIKeyCommand(),
 		},
@@ -31,18 +30,6 @@ func listProjectAPIKeysCommand() *cli.Command {
 			afterFlag,
 		},
 		Action: listProjectAPIKeys,
-	}
-}
-
-func createProjectAPIKeyCommand() *cli.Command {
-	return &cli.Command{
-		Name:  "create",
-		Usage: "Create a new project API key",
-		Flags: []cli.Flag{
-			projectIDFlag,
-			nameFlag,
-		},
-		Action: createProjectAPIKey,
 	}
 }
 
@@ -101,39 +88,6 @@ func listProjectAPIKeys(ctx context.Context, cmd *cli.Command) error {
 				key.CreatedAt.String(),
 				key.Owner.String(),
 			}
-		}
-		printTableData(data)
-	}
-	return nil
-}
-
-func createProjectAPIKey(ctx context.Context, cmd *cli.Command) error {
-	client := newClient(ctx, cmd)
-
-	apiKey, err := client.CreateProjectApiKey(
-		cmd.String("project-id"),
-		cmd.String("name"),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create project API key: %w", err)
-	}
-
-	switch cmd.String("output") {
-	case "json":
-		data, err := json.Marshal(apiKey)
-		if err != nil {
-			return fmt.Errorf("failed to marshal API key: %w", err)
-		}
-		fmt.Println(string(data))
-	default:
-		data := TableData{
-			Headers: []string{"ID", "Name", "Created At", "Owner"},
-			Rows: [][]string{{
-				apiKey.ID,
-				apiKey.Name,
-				apiKey.CreatedAt.String(),
-				apiKey.Owner.String(),
-			}},
 		}
 		printTableData(data)
 	}

--- a/cmd/project_api_keys.go
+++ b/cmd/project_api_keys.go
@@ -75,7 +75,7 @@ func listProjectAPIKeys(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal API keys: %w", err)
 		}
-		fmt.Println(string(data))
+		fmt.Printf("Retrieved %d API keys.\n", len(apiKeys.Data))
 	default:
 		data := TableData{
 			Headers: []string{"ID", "Name", "Created At", "Owner"},

--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,146 @@
+# OpenAI Organizations MCP Server Commands
+
+## Current Commands
+- list_projects: Lists all projects for the authenticated user
+
+## MCP Resources and Templates
+
+### Static Resources
+These are application-controlled resources representing current state:
+
+1. Active Projects
+   - URI: openai-orgs://active-projects
+   - MIME Type: application/vnd.openai-orgs.project-list+json
+   - Description: Currently active projects in the organization
+   - Supports: Pagination, Subscribe for updates
+
+2. Current Members
+   - URI: openai-orgs://current-members
+   - MIME Type: application/vnd.openai-orgs.member-list+json
+   - Description: Current organization members
+   - Supports: Pagination, Subscribe for updates
+
+3. Usage Dashboard
+   - URI: openai-orgs://usage-dashboard
+   - MIME Type: application/vnd.openai-orgs.usage+json
+   - Description: Current usage statistics dashboard
+   - Supports: Subscribe for real-time updates
+
+### Resource Templates
+These allow parameterized access to resources:
+
+1. Project Template
+   - URI Template: openai-orgs://projects/{project_id}
+   - MIME Type: application/vnd.openai-orgs.project+json
+   - Description: Access specific project details
+   - Parameters:
+     - project_id: The unique identifier of the project
+
+2. Member Template
+   - URI Template: openai-orgs://members/{member_id}
+   - MIME Type: application/vnd.openai-orgs.member+json
+   - Description: Access specific member details
+   - Parameters:
+     - member_id: The unique identifier of the member
+
+3. Usage Template
+   - URI Template: openai-orgs://usage/{metric_id}
+   - MIME Type: application/vnd.openai-orgs.usage+json
+   - Description: Access specific usage metrics
+   - Parameters:
+     - metric_id: The identifier for specific usage metrics
+
+### Implementation Priority
+
+1. Static Resources (Phase 1)
+   - Active Projects resource
+   - Current Members resource
+   - Usage Dashboard resource
+   - Implement real-time updates via subscriptions
+
+2. Resource Templates (Phase 2)
+   - Project template with parameter validation
+   - Member template with role-based access
+   - Usage template with metric validation
+
+### Resource Implementation Notes
+
+1. Static Resources:
+   - Implement as concrete resources in resources.go
+   - Add real-time update support
+   - Implement proper caching
+   - Add pagination support
+   - Example:
+     ```go
+     // Register concrete resources
+     s.AddResource("openai-orgs://active-projects", handleActiveProjects)
+     s.AddResource("openai-orgs://current-members", handleCurrentMembers)
+     s.AddResource("openai-orgs://usage-dashboard", handleUsageDashboard)
+     ```
+
+2. Resource Templates:
+   - Implement as URI templates
+   - Add parameter validation
+   - Support dynamic resource generation
+   - Example:
+     ```go
+     // Register resource templates
+     s.AddResourceTemplate(projectTemplate, handleProjectResource)
+     s.AddResourceTemplate(memberTemplate, handleMemberResource)
+     s.AddResourceTemplate(usageTemplate, handleUsageResource)
+     ```
+
+3. Error Handling:
+   - Standard error responses for both types
+   - Proper error wrapping
+   - Context preservation
+
+4. Resource Capabilities:
+   - subscribe: true (for real-time updates)
+   - listChanged: true (for resource list updates)
+   - Implement proper MIME types
+   - Configure pagination defaults
+
+5. Testing Strategy:
+   - Unit tests for both resource types
+   - Integration tests for real-time updates
+   - Load testing for pagination
+   - Parameter validation tests for templates
+
+## Resource URI Structure
+- Projects: openai-orgs://projects/{project_id}
+- Members: openai-orgs://members/{member_id}
+- Usage: openai-orgs://usage/{metric_id}
+
+## Server Integration Steps
+1. Resource Registration:
+   - Import the resources package in server.go
+   - Call AddResources() in NewMCPServer() initialization
+   - Example:
+     ```go
+     func NewMCPServer() *server.MCPServer {
+         mcpServer := server.NewMCPServer(
+             serverName,
+             version,
+             server.WithInstructions(instructions),
+             server.WithLogging(),
+             server.WithToolCapabilities(true),
+             server.WithResourceCapabilities(true, true), // Enable resource capabilities
+         )
+
+         AddTools(mcpServer)
+         AddResources(mcpServer)  // Register all resources
+         return mcpServer
+     }
+     ```
+
+2. Resource Capabilities:
+   - Enable resource capabilities in server initialization
+   - Set up proper MIME types for each resource type
+   - Configure pagination defaults and limits
+
+3. Testing:
+   - Verify resource registration
+   - Test URI template matching
+   - Validate pagination behavior
+   - Check error handling

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,14 @@ require github.com/go-resty/resty/v2 v2.16.5
 
 require github.com/urfave/cli/v3 v3.1.1
 
+require go.uber.org/mock v0.5.1 // indirect
+
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/mark3labs/mcp-go v0.21.1
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+)
+
 require (
 	github.com/jarcoal/httpmock v1.4.0
 	golang.org/x/net v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
 github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/mark3labs/mcp-go v0.21.1 h1:7Ek6KPIIbMhEYHRiRIg6K6UAgNZCJaHKQp926MNr6V0=
+github.com/mark3labs/mcp-go v0.21.1/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
 github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -12,6 +16,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v3 v3.1.1 h1:bNnl8pFI5dxPOjeONvFCDFoECLQsceDG4ejahs4Jtxk=
 github.com/urfave/cli/v3 v3.1.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+go.uber.org/mock v0.5.1 h1:ASgazW/qBmR+A32MYFDB6E2POoTgOwT509VP0CT/fjs=
+go.uber.org/mock v0.5.1/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=

--- a/invites.go
+++ b/invites.go
@@ -73,3 +73,13 @@ func (c *Client) DeleteInvite(id string) error {
 
 	return nil
 }
+
+// String returns a human-readable string representation of the Invite
+func (i *Invite) String() string {
+	acceptedInfo := ""
+	if i.AcceptedAt != nil {
+		acceptedInfo = fmt.Sprintf(", Accepted: %s", i.AcceptedAt.String())
+	}
+	return fmt.Sprintf("Invite{ID: %s, Email: %s, Role: %s, Status: %s%s}",
+		i.ID, i.Email, i.Role, i.Status, acceptedInfo)
+}

--- a/pkg/mcp/auth.go
+++ b/pkg/mcp/auth.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+)
+
+type authToken struct{}
+
+var (
+	ErrNoAuthToken = errors.New("no auth token found in context")
+	ErrEmptyToken  = errors.New("empty auth token provided")
+)
+
+func withAuthToken(c context.Context, auth string) context.Context {
+	if auth == "" {
+		return c
+	}
+	return context.WithValue(c, authToken{}, auth)
+}
+
+func AuthFromEnvironment(c context.Context) context.Context {
+	token := os.Getenv("OPENAI_API_KEY")
+	return withAuthToken(c, token)
+}

--- a/pkg/mcp/resource_templates.go
+++ b/pkg/mcp/resource_templates.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	openaiorgs "github.com/klauern/openai-orgs"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Resource template types and MIME types
+const (
+	ResourceTemplateTypeProject               = "project"
+	ResourceTemplateTypeMember                = "member"
+	ResourceTemplateTypeUsage                 = "usage"
+	ResourceTemplateTypeProjectServiceAccount = "project-service-account"
+
+	MIMETypeProjectTemplate               = "application/vnd.openai-orgs.project+json"
+	MIMETypeMemberTemplate                = "application/vnd.openai-orgs.member+json"
+	MIMETypeUsageTemplate                 = "application/vnd.openai-orgs.usage+json"
+	MIMETypeProjectServiceAccountTemplate = "application/vnd.openai-orgs.project-service-account+json"
+)
+
+// templateHandler is a generic handler for resource templates
+type templateHandler func(ctx context.Context, client *openaiorgs.Client, uri *ResourceURI) (interface{}, error)
+
+// AddResourceTemplates adds resource template capabilities to the MCP server
+func AddResourceTemplates(s *server.MCPServer) {
+	templates := []struct {
+		path     string
+		name     string
+		desc     string
+		mimeType string
+		handler  templateHandler
+	}{
+		{
+			path:     "openai-orgs://project/{id}",
+			name:     "OpenAI Project",
+			desc:     "OpenAI project information",
+			mimeType: MIMETypeProjectTemplate,
+			handler:  handleProject,
+		},
+		{
+			path:     "openai-orgs://members/{id}",
+			name:     "Organization Member",
+			desc:     "OpenAI organization member information",
+			mimeType: MIMETypeMemberTemplate,
+			handler:  handleMember,
+		},
+		{
+			path:     "openai-orgs://usage/{id}",
+			name:     "Usage Statistics",
+			desc:     "OpenAI organization usage statistics",
+			mimeType: MIMETypeUsageTemplate,
+			handler:  handleUsage,
+		},
+		{
+			path:     "openai-orgs://project/{id}/service-account/{serviceAccountID}",
+			name:     "Project Service Account",
+			desc:     "OpenAI project service account information",
+			mimeType: MIMETypeProjectServiceAccountTemplate,
+			handler:  handleProjectServiceAccount,
+		},
+	}
+
+	for _, t := range templates {
+		template := mcp.NewResourceTemplate(
+			t.path,
+			t.name,
+			mcp.WithTemplateDescription(t.desc),
+			mcp.WithTemplateMIMEType(t.mimeType),
+		)
+
+		// Create a closure to capture the handler and MIME type
+		handler := createTemplateHandler(t.handler, t.mimeType)
+		s.AddResourceTemplate(template, handler)
+	}
+}
+
+// createTemplateHandler creates a standard MCP handler from our template handler
+func createTemplateHandler(h templateHandler, mimeType string) func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		authToken := ctx.Value(authToken{}).(string)
+		if authToken == "" {
+			return nil, ErrNoAuthToken
+		}
+
+		uri, err := ParseURI(request.Params.URI)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URI: %w", err)
+		}
+
+		client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+		data, err := h(ctx, client, uri)
+		if err != nil {
+			return nil, err
+		}
+
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal response data: %w", err)
+		}
+
+		contents := &mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: mimeType,
+			Text:     string(jsonData),
+		}
+
+		return []mcp.ResourceContents{contents}, nil
+	}
+}
+
+// Individual handlers for each template type
+func handleProject(_ context.Context, client *openaiorgs.Client, uri *ResourceURI) (interface{}, error) {
+	return client.RetrieveProject(uri.ProjectID)
+}
+
+func handleMember(_ context.Context, client *openaiorgs.Client, uri *ResourceURI) (interface{}, error) {
+	return client.RetrieveUser(uri.MemberID)
+}
+
+func handleProjectServiceAccount(_ context.Context, client *openaiorgs.Client, uri *ResourceURI) (interface{}, error) {
+	return client.RetrieveProjectServiceAccount(uri.ProjectID, uri.ServiceAccount)
+}
+
+func handleUsage(_ context.Context, client *openaiorgs.Client, uri *ResourceURI) (interface{}, error) {
+	usageData := make(map[string]interface{})
+	params := map[string]string{
+		"start_time": "0",
+		"project_id": uri.ProjectID,
+	}
+
+	// Get all types of usage for comprehensive data
+	if completions, err := client.GetCompletionsUsage(params); err == nil {
+		usageData["completions"] = completions
+	}
+	if embeddings, err := client.GetEmbeddingsUsage(params); err == nil {
+		usageData["embeddings"] = embeddings
+	}
+	if images, err := client.GetImagesUsage(params); err == nil {
+		usageData["images"] = images
+	}
+
+	return usageData, nil
+}

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,38 +12,168 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-// Resource types
+// Resource types and MIME types
 const (
-	ResourceTypeProject = "project"
-	ResourceTypeMember  = "member"
-	ResourceTypeUsage   = "usage"
-)
+	ResourceTypeActiveProjects = "active-projects"
+	ResourceTypeCurrentMembers = "current-members"
+	ResourceTypeUsageDashboard = "usage-dashboard"
 
-// MIME types for our resources
-const (
-	MIMETypeProject = "application/vnd.openai-orgs.project+json"
-	MIMETypeMember  = "application/vnd.openai-orgs.member+json"
-	MIMETypeUsage   = "application/vnd.openai-orgs.usage+json"
-	MIMETypeList    = "application/vnd.openai-orgs.list+json"
-)
+	MIMETypeProjectList    = "application/vnd.openai-orgs.project-list+json"
+	MIMETypeMemberList     = "application/vnd.openai-orgs.member-list+json"
+	MIMETypeUsageDashboard = "application/vnd.openai-orgs.usage+json"
 
-// Default pagination values
-const (
 	defaultPageSize = 20
 	maxPageSize     = 100
 )
 
-// ResourceParams extends the base ReadResourceRequest parameters
-type ResourceParams struct {
-	URI       string                 `json:"uri"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
-	Subscribe bool                   `json:"subscribe,omitempty"`
-	Context   context.Context        `json:"-"`
+// resourceHandler is a generic handler for resources
+type resourceHandler func(ctx context.Context, client *openaiorgs.Client, params map[string]interface{}) (interface{}, error)
+
+// AddResources adds static resource capabilities to the MCP server
+func AddResources(s *server.MCPServer) {
+	resources := []struct {
+		uri      string
+		name     string
+		desc     string
+		mimeType string
+		handler  resourceHandler
+	}{
+		{
+			uri:      "openai-orgs://active-projects",
+			name:     "Active Projects",
+			desc:     "Currently active projects in the organization",
+			mimeType: MIMETypeProjectList,
+			handler:  handleActiveProjects,
+		},
+		{
+			uri:      "openai-orgs://current-members",
+			name:     "Current Members",
+			desc:     "Current organization members",
+			mimeType: MIMETypeMemberList,
+			handler:  handleCurrentMembers,
+		},
+		{
+			uri:      "openai-orgs://usage-dashboard",
+			name:     "Usage Dashboard",
+			desc:     "Current usage statistics dashboard",
+			mimeType: MIMETypeUsageDashboard,
+			handler:  handleUsageDashboard,
+		},
+	}
+
+	for _, r := range resources {
+		resource := mcp.NewResource(
+			r.uri,
+			r.name,
+			mcp.WithResourceDescription(r.desc),
+			mcp.WithMIMEType(r.mimeType),
+		)
+
+		handler := createResourceHandler(r.handler, r.mimeType)
+		s.AddResource(resource, handler)
+	}
+
+	// Start background polling for changes
+	go pollForChanges(context.Background())
 }
 
-// ResourceRequest wraps the resource request with extended parameters
-type ResourceRequest struct {
-	Params ResourceParams
+// createResourceHandler creates a standard MCP handler from our resource handler
+func createResourceHandler(h resourceHandler, mimeType string) func(context.Context, mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		authToken := ctx.Value(authToken{}).(string)
+		if authToken == "" {
+			return nil, ErrNoAuthToken
+		}
+
+		client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+		// Extract pagination and other parameters
+		params := make(map[string]interface{})
+		if request.Params.Arguments != nil {
+			params = request.Params.Arguments
+		}
+
+		data, err := h(ctx, client, params)
+		if err != nil {
+			return nil, err
+		}
+
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal response data: %w", err)
+		}
+
+		contents := &mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: mimeType,
+			Text:     string(jsonData),
+		}
+
+		// Handle subscription if requested
+		if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
+			ch := subManager.subscribe(request.Params.URI)
+			go func() {
+				<-ctx.Done()
+				subManager.unsubscribe(request.Params.URI, ch)
+			}()
+		}
+
+		return []mcp.ResourceContents{contents}, nil
+	}
+}
+
+// Individual handlers for each resource type
+func handleActiveProjects(_ context.Context, client *openaiorgs.Client, params map[string]interface{}) (interface{}, error) {
+	limit, after := getPaginationFromParams(params)
+	return client.ListProjects(limit, after, true)
+}
+
+func handleCurrentMembers(_ context.Context, client *openaiorgs.Client, params map[string]interface{}) (interface{}, error) {
+	limit, after := getPaginationFromParams(params)
+	return client.ListUsers(limit, after)
+}
+
+func handleUsageDashboard(_ context.Context, client *openaiorgs.Client, _ map[string]interface{}) (interface{}, error) {
+	startTime := time.Now().AddDate(0, -1, 0).Format(time.RFC3339) // Last month
+	params := map[string]string{"start_time": startTime}
+
+	usageData := make(map[string]interface{})
+
+	if completions, err := client.GetCompletionsUsage(params); err == nil {
+		usageData["completions"] = completions
+	}
+	if embeddings, err := client.GetEmbeddingsUsage(params); err == nil {
+		usageData["embeddings"] = embeddings
+	}
+	if images, err := client.GetImagesUsage(params); err == nil {
+		usageData["images"] = images
+	}
+
+	return usageData, nil
+}
+
+// Helper functions
+
+func getPaginationFromParams(params map[string]interface{}) (limit int, after string) {
+	limit = defaultPageSize
+
+	if pagination, ok := params["pagination"].(map[string]interface{}); ok {
+		if afterVal, ok := pagination["after"].(string); ok {
+			after = afterVal
+		}
+		if limitVal, ok := pagination["limit"].(float64); ok {
+			limit = int(limitVal)
+		}
+	}
+
+	if limit <= 0 {
+		limit = defaultPageSize
+	}
+	if limit > maxPageSize {
+		limit = maxPageSize
+	}
+
+	return limit, after
 }
 
 // Subscription management
@@ -91,321 +219,7 @@ func (sm *subscriptionManager) notify(uri string, contents mcp.ResourceContents)
 	}
 }
 
-// AddResources adds resource capabilities to the MCP server
-func AddResources(s *server.MCPServer) {
-	// Create resource templates for each type
-	projectTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://projects/{id}",
-		"OpenAI Project",
-		mcp.WithTemplateDescription("OpenAI project information"),
-		mcp.WithTemplateMIMEType(MIMETypeProject),
-	)
-
-	memberTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://members/{id}",
-		"Organization Member",
-		mcp.WithTemplateDescription("OpenAI organization member information"),
-		mcp.WithTemplateMIMEType(MIMETypeMember),
-	)
-
-	usageTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://usage/{id}",
-		"Usage Statistics",
-		mcp.WithTemplateDescription("OpenAI organization usage statistics"),
-		mcp.WithTemplateMIMEType(MIMETypeUsage),
-	)
-
-	// List templates
-	projectListTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://projects",
-		"OpenAI Projects List",
-		mcp.WithTemplateDescription("List of OpenAI projects"),
-		mcp.WithTemplateMIMEType(MIMETypeList),
-	)
-
-	memberListTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://members",
-		"Organization Members List",
-		mcp.WithTemplateDescription("List of organization members"),
-		mcp.WithTemplateMIMEType(MIMETypeList),
-	)
-
-	usageListTemplate := mcp.NewResourceTemplate(
-		"openai-orgs://usage",
-		"Usage Statistics List",
-		mcp.WithTemplateDescription("List of usage statistics"),
-		mcp.WithTemplateMIMEType(MIMETypeList),
-	)
-
-	// Add resource templates with their handlers
-	s.AddResourceTemplate(projectTemplate, handleProjectResource)
-	s.AddResourceTemplate(memberTemplate, handleMemberResource)
-	s.AddResourceTemplate(usageTemplate, handleUsageResource)
-	s.AddResourceTemplate(projectListTemplate, handleListProjectsResource)
-	s.AddResourceTemplate(memberListTemplate, handleListMembersResource)
-	s.AddResourceTemplate(usageListTemplate, handleListUsageResource)
-
-	// Start background polling for changes
-	go pollForChanges(context.Background())
-}
-
-// getPaginationParams extracts pagination parameters from the request
-func getPaginationParams(request mcp.ReadResourceRequest) (page int, limit string) {
-	if args, ok := request.Params.Arguments["pagination"].(map[string]interface{}); ok {
-		if pageNum, ok := args["page"].(float64); ok {
-			page = int(pageNum)
-		}
-		if limitStr, ok := args["limit"].(string); ok {
-			limit = limitStr
-		}
-	}
-
-	if page < 1 {
-		page = 1
-	}
-
-	if limit == "" {
-		limit = strconv.Itoa(defaultPageSize)
-	}
-
-	if limitInt, err := strconv.Atoi(limit); err == nil && limitInt > maxPageSize {
-		limit = strconv.Itoa(maxPageSize)
-	}
-
-	return page, limit
-}
-
-// handleListProjectsResource handles project list requests
-func handleListProjectsResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	page, limit := getPaginationParams(request)
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-
-	projects, err := client.ListProjects(page, limit, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list projects: %w", err)
-	}
-
-	data, err := json.Marshal(projects)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal projects data: %w", err)
-	}
-
-	return []mcp.ResourceContents{
-		&mcp.TextResourceContents{
-			URI:      request.Params.URI,
-			MIMEType: MIMETypeList,
-			Text:     string(data),
-		},
-	}, nil
-}
-
-// handleListMembersResource handles member list requests
-func handleListMembersResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	page, limit := getPaginationParams(request)
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-
-	// For now, we'll use ListUsers as a proxy for members since the API doesn't have a direct members endpoint
-	users, err := client.ListUsers(page, limit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list members: %w", err)
-	}
-
-	data, err := json.Marshal(users)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal members data: %w", err)
-	}
-
-	return []mcp.ResourceContents{
-		&mcp.TextResourceContents{
-			URI:      request.Params.URI,
-			MIMEType: MIMETypeList,
-			Text:     string(data),
-		},
-	}, nil
-}
-
-// handleListUsageResource handles usage list requests
-func handleListUsageResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-
-	// For usage, we'll use GetCompletionsUsage since there's no list endpoint
-	// We'll paginate the results client-side if needed
-	usage, err := client.GetCompletionsUsage(map[string]string{
-		"start_time": "0", // Get all available data
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get usage data: %w", err)
-	}
-
-	data, err := json.Marshal(usage)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal usage data: %w", err)
-	}
-
-	return []mcp.ResourceContents{
-		&mcp.TextResourceContents{
-			URI:      request.Params.URI,
-			MIMEType: MIMETypeList,
-			Text:     string(data),
-		},
-	}, nil
-}
-
-// handleProjectResource handles project resource requests
-func handleProjectResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	projectID := request.Params.URI[len("openai-orgs://projects/"):]
-
-	project, err := client.RetrieveProject(projectID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve project: %w", err)
-	}
-
-	data, err := json.Marshal(project)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal project data: %w", err)
-	}
-
-	contents := &mcp.TextResourceContents{
-		URI:      request.Params.URI,
-		MIMEType: MIMETypeProject,
-		Text:     string(data),
-	}
-
-	// Handle subscription if requested
-	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
-		ch := subManager.subscribe(request.Params.URI)
-		go func() {
-			<-ctx.Done()
-			subManager.unsubscribe(request.Params.URI, ch)
-		}()
-	}
-
-	return []mcp.ResourceContents{contents}, nil
-}
-
-// handleMemberResource handles member resource requests
-func handleMemberResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	userID := request.Params.URI[len("openai-orgs://members/"):]
-
-	user, err := client.RetrieveUser(userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve user: %w", err)
-	}
-
-	data, err := json.Marshal(user)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal user data: %w", err)
-	}
-
-	contents := &mcp.TextResourceContents{
-		URI:      request.Params.URI,
-		MIMEType: MIMETypeMember,
-		Text:     string(data),
-	}
-
-	// Handle subscription if requested
-	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
-		ch := subManager.subscribe(request.Params.URI)
-		go func() {
-			<-ctx.Done()
-			subManager.unsubscribe(request.Params.URI, ch)
-		}()
-	}
-
-	return []mcp.ResourceContents{contents}, nil
-}
-
-// handleUsageResource handles usage resource requests
-func handleUsageResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-	authToken := ctx.Value(authToken{}).(string)
-	if authToken == "" {
-		return nil, ErrNoAuthToken
-	}
-
-	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	projectID := request.Params.URI[len("openai-orgs://usage/"):]
-
-	// Get all types of usage for comprehensive data
-	usageData := make(map[string]interface{})
-
-	// Get completions usage
-	completions, err := client.GetCompletionsUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
-		usageData["completions"] = completions
-	}
-
-	// Get embeddings usage
-	embeddings, err := client.GetEmbeddingsUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
-		usageData["embeddings"] = embeddings
-	}
-
-	// Get images usage
-	images, err := client.GetImagesUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
-		usageData["images"] = images
-	}
-
-	data, err := json.Marshal(usageData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal usage data: %w", err)
-	}
-
-	contents := &mcp.TextResourceContents{
-		URI:      request.Params.URI,
-		MIMEType: MIMETypeUsage,
-		Text:     string(data),
-	}
-
-	// Handle subscription if requested
-	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
-		ch := subManager.subscribe(request.Params.URI)
-		go func() {
-			<-ctx.Done()
-			subManager.unsubscribe(request.Params.URI, ch)
-		}()
-	}
-
-	return []mcp.ResourceContents{contents}, nil
-}
-
-// pollForChanges periodically checks for changes in resources
+// Background polling
 func pollForChanges(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -415,131 +229,103 @@ func pollForChanges(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Poll for changes and notify subscribers
 			checkForResourceChanges(ctx)
 		}
 	}
 }
 
 func checkForResourceChanges(ctx context.Context) {
-	// This is a simplified implementation. In production, you'd want to:
-	// 1. Keep track of last known state
-	// 2. Compare with current state
-	// 3. Only notify on actual changes
-	// 4. Handle rate limiting
-	// 5. Implement proper error handling and backoff
-
 	subManager.RLock()
 	defer subManager.RUnlock()
 
 	for uri := range subManager.subscribers {
-		// Based on URI pattern, fetch appropriate resource
-		switch {
-		case strings.HasPrefix(uri, "openai-orgs://projects/"):
-			go updateProjectResource(ctx, uri)
-		case strings.HasPrefix(uri, "openai-orgs://members/"):
-			go updateMemberResource(ctx, uri)
-		case strings.HasPrefix(uri, "openai-orgs://usage/"):
-			go updateUsageResource(ctx, uri)
+		parsedURI, err := ParseURI(uri)
+		if err != nil {
+			continue
+		}
+
+		switch parsedURI.Type {
+		case ResourceTypeActiveProjects:
+			go updateActiveProjects(ctx)
+		case ResourceTypeCurrentMembers:
+			go updateCurrentMembers(ctx)
+		case ResourceTypeUsageDashboard:
+			go updateUsageDashboard(ctx)
 		}
 	}
 }
 
-// updateProjectResource updates a project's resource data
-func updateProjectResource(ctx context.Context, uri string) {
+// Update functions for each resource type
+func updateActiveProjects(ctx context.Context) {
 	authToken := ctx.Value(authToken{}).(string)
 	if authToken == "" {
 		return
 	}
 
 	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	projectID := uri[len("openai-orgs://projects/"):]
-
-	project, err := client.RetrieveProject(projectID)
+	projects, err := client.ListProjects(defaultPageSize, "", true)
 	if err != nil {
 		return
 	}
 
-	data, err := json.Marshal(project)
+	data, err := json.Marshal(projects)
 	if err != nil {
 		return
 	}
 
 	contents := &mcp.TextResourceContents{
-		URI:      uri,
-		MIMEType: MIMETypeProject,
+		URI:      "openai-orgs://active-projects",
+		MIMEType: MIMETypeProjectList,
 		Text:     string(data),
 	}
 
-	subManager.notify(uri, contents)
+	subManager.notify("openai-orgs://active-projects", contents)
 }
 
-// updateMemberResource updates a member's resource data
-func updateMemberResource(ctx context.Context, uri string) {
+func updateCurrentMembers(ctx context.Context) {
 	authToken := ctx.Value(authToken{}).(string)
 	if authToken == "" {
 		return
 	}
 
 	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	userID := uri[len("openai-orgs://members/"):]
-
-	user, err := client.RetrieveUser(userID)
+	members, err := client.ListUsers(defaultPageSize, "")
 	if err != nil {
 		return
 	}
 
-	data, err := json.Marshal(user)
+	data, err := json.Marshal(members)
 	if err != nil {
 		return
 	}
 
 	contents := &mcp.TextResourceContents{
-		URI:      uri,
-		MIMEType: MIMETypeMember,
+		URI:      "openai-orgs://current-members",
+		MIMEType: MIMETypeMemberList,
 		Text:     string(data),
 	}
 
-	subManager.notify(uri, contents)
+	subManager.notify("openai-orgs://current-members", contents)
 }
 
-// updateUsageResource updates usage resource data
-func updateUsageResource(ctx context.Context, uri string) {
+func updateUsageDashboard(ctx context.Context) {
 	authToken := ctx.Value(authToken{}).(string)
 	if authToken == "" {
 		return
 	}
 
 	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
-	projectID := uri[len("openai-orgs://usage/"):]
+	startTime := time.Now().AddDate(0, -1, 0).Format(time.RFC3339)
+	params := map[string]string{"start_time": startTime}
 
-	// Get all types of usage for comprehensive data
 	usageData := make(map[string]interface{})
-
-	// Get completions usage
-	completions, err := client.GetCompletionsUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
+	if completions, err := client.GetCompletionsUsage(params); err == nil {
 		usageData["completions"] = completions
 	}
-
-	// Get embeddings usage
-	embeddings, err := client.GetEmbeddingsUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
+	if embeddings, err := client.GetEmbeddingsUsage(params); err == nil {
 		usageData["embeddings"] = embeddings
 	}
-
-	// Get images usage
-	images, err := client.GetImagesUsage(map[string]string{
-		"start_time": "0",
-		"project_id": projectID,
-	})
-	if err == nil {
+	if images, err := client.GetImagesUsage(params); err == nil {
 		usageData["images"] = images
 	}
 
@@ -549,10 +335,10 @@ func updateUsageResource(ctx context.Context, uri string) {
 	}
 
 	contents := &mcp.TextResourceContents{
-		URI:      uri,
-		MIMEType: MIMETypeUsage,
+		URI:      "openai-orgs://usage-dashboard",
+		MIMEType: MIMETypeUsageDashboard,
 		Text:     string(data),
 	}
 
-	subManager.notify(uri, contents)
+	subManager.notify("openai-orgs://usage-dashboard", contents)
 }

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -1,0 +1,558 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	openaiorgs "github.com/klauern/openai-orgs"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Resource types
+const (
+	ResourceTypeProject = "project"
+	ResourceTypeMember  = "member"
+	ResourceTypeUsage   = "usage"
+)
+
+// MIME types for our resources
+const (
+	MIMETypeProject = "application/vnd.openai-orgs.project+json"
+	MIMETypeMember  = "application/vnd.openai-orgs.member+json"
+	MIMETypeUsage   = "application/vnd.openai-orgs.usage+json"
+	MIMETypeList    = "application/vnd.openai-orgs.list+json"
+)
+
+// Default pagination values
+const (
+	defaultPageSize = 20
+	maxPageSize     = 100
+)
+
+// ResourceParams extends the base ReadResourceRequest parameters
+type ResourceParams struct {
+	URI       string                 `json:"uri"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	Subscribe bool                   `json:"subscribe,omitempty"`
+	Context   context.Context        `json:"-"`
+}
+
+// ResourceRequest wraps the resource request with extended parameters
+type ResourceRequest struct {
+	Params ResourceParams
+}
+
+// Subscription management
+type subscriptionManager struct {
+	sync.RWMutex
+	subscribers map[string][]chan mcp.ResourceContents
+}
+
+var subManager = &subscriptionManager{
+	subscribers: make(map[string][]chan mcp.ResourceContents),
+}
+
+func (sm *subscriptionManager) subscribe(uri string) chan mcp.ResourceContents {
+	sm.Lock()
+	defer sm.Unlock()
+	ch := make(chan mcp.ResourceContents, 1)
+	sm.subscribers[uri] = append(sm.subscribers[uri], ch)
+	return ch
+}
+
+func (sm *subscriptionManager) unsubscribe(uri string, ch chan mcp.ResourceContents) {
+	sm.Lock()
+	defer sm.Unlock()
+	subs := sm.subscribers[uri]
+	for i, sub := range subs {
+		if sub == ch {
+			sm.subscribers[uri] = append(subs[:i], subs[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+}
+
+func (sm *subscriptionManager) notify(uri string, contents mcp.ResourceContents) {
+	sm.RLock()
+	defer sm.RUnlock()
+	for _, ch := range sm.subscribers[uri] {
+		select {
+		case ch <- contents:
+		default:
+			// Channel is full, skip notification
+		}
+	}
+}
+
+// AddResources adds resource capabilities to the MCP server
+func AddResources(s *server.MCPServer) {
+	// Create resource templates for each type
+	projectTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://projects/{id}",
+		"OpenAI Project",
+		mcp.WithTemplateDescription("OpenAI project information"),
+		mcp.WithTemplateMIMEType(MIMETypeProject),
+	)
+
+	memberTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://members/{id}",
+		"Organization Member",
+		mcp.WithTemplateDescription("OpenAI organization member information"),
+		mcp.WithTemplateMIMEType(MIMETypeMember),
+	)
+
+	usageTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://usage/{id}",
+		"Usage Statistics",
+		mcp.WithTemplateDescription("OpenAI organization usage statistics"),
+		mcp.WithTemplateMIMEType(MIMETypeUsage),
+	)
+
+	// List templates
+	projectListTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://projects",
+		"OpenAI Projects List",
+		mcp.WithTemplateDescription("List of OpenAI projects"),
+		mcp.WithTemplateMIMEType(MIMETypeList),
+	)
+
+	memberListTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://members",
+		"Organization Members List",
+		mcp.WithTemplateDescription("List of organization members"),
+		mcp.WithTemplateMIMEType(MIMETypeList),
+	)
+
+	usageListTemplate := mcp.NewResourceTemplate(
+		"openai-orgs://usage",
+		"Usage Statistics List",
+		mcp.WithTemplateDescription("List of usage statistics"),
+		mcp.WithTemplateMIMEType(MIMETypeList),
+	)
+
+	// Add resource templates with their handlers
+	s.AddResourceTemplate(projectTemplate, handleProjectResource)
+	s.AddResourceTemplate(memberTemplate, handleMemberResource)
+	s.AddResourceTemplate(usageTemplate, handleUsageResource)
+	s.AddResourceTemplate(projectListTemplate, handleListProjectsResource)
+	s.AddResourceTemplate(memberListTemplate, handleListMembersResource)
+	s.AddResourceTemplate(usageListTemplate, handleListUsageResource)
+
+	// Start background polling for changes
+	go pollForChanges(context.Background())
+}
+
+// getPaginationParams extracts pagination parameters from the request
+func getPaginationParams(request mcp.ReadResourceRequest) (page int, limit string) {
+	if args, ok := request.Params.Arguments["pagination"].(map[string]interface{}); ok {
+		if pageNum, ok := args["page"].(float64); ok {
+			page = int(pageNum)
+		}
+		if limitStr, ok := args["limit"].(string); ok {
+			limit = limitStr
+		}
+	}
+
+	if page < 1 {
+		page = 1
+	}
+
+	if limit == "" {
+		limit = strconv.Itoa(defaultPageSize)
+	}
+
+	if limitInt, err := strconv.Atoi(limit); err == nil && limitInt > maxPageSize {
+		limit = strconv.Itoa(maxPageSize)
+	}
+
+	return page, limit
+}
+
+// handleListProjectsResource handles project list requests
+func handleListProjectsResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	page, limit := getPaginationParams(request)
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+	projects, err := client.ListProjects(page, limit, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+
+	data, err := json.Marshal(projects)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal projects data: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		&mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: MIMETypeList,
+			Text:     string(data),
+		},
+	}, nil
+}
+
+// handleListMembersResource handles member list requests
+func handleListMembersResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	page, limit := getPaginationParams(request)
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+	// For now, we'll use ListUsers as a proxy for members since the API doesn't have a direct members endpoint
+	users, err := client.ListUsers(page, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list members: %w", err)
+	}
+
+	data, err := json.Marshal(users)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal members data: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		&mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: MIMETypeList,
+			Text:     string(data),
+		},
+	}, nil
+}
+
+// handleListUsageResource handles usage list requests
+func handleListUsageResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+	// For usage, we'll use GetCompletionsUsage since there's no list endpoint
+	// We'll paginate the results client-side if needed
+	usage, err := client.GetCompletionsUsage(map[string]string{
+		"start_time": "0", // Get all available data
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get usage data: %w", err)
+	}
+
+	data, err := json.Marshal(usage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal usage data: %w", err)
+	}
+
+	return []mcp.ResourceContents{
+		&mcp.TextResourceContents{
+			URI:      request.Params.URI,
+			MIMEType: MIMETypeList,
+			Text:     string(data),
+		},
+	}, nil
+}
+
+// handleProjectResource handles project resource requests
+func handleProjectResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	projectID := request.Params.URI[len("openai-orgs://projects/"):]
+
+	project, err := client.RetrieveProject(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve project: %w", err)
+	}
+
+	data, err := json.Marshal(project)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal project data: %w", err)
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      request.Params.URI,
+		MIMEType: MIMETypeProject,
+		Text:     string(data),
+	}
+
+	// Handle subscription if requested
+	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
+		ch := subManager.subscribe(request.Params.URI)
+		go func() {
+			<-ctx.Done()
+			subManager.unsubscribe(request.Params.URI, ch)
+		}()
+	}
+
+	return []mcp.ResourceContents{contents}, nil
+}
+
+// handleMemberResource handles member resource requests
+func handleMemberResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	userID := request.Params.URI[len("openai-orgs://members/"):]
+
+	user, err := client.RetrieveUser(userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve user: %w", err)
+	}
+
+	data, err := json.Marshal(user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal user data: %w", err)
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      request.Params.URI,
+		MIMEType: MIMETypeMember,
+		Text:     string(data),
+	}
+
+	// Handle subscription if requested
+	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
+		ch := subManager.subscribe(request.Params.URI)
+		go func() {
+			<-ctx.Done()
+			subManager.unsubscribe(request.Params.URI, ch)
+		}()
+	}
+
+	return []mcp.ResourceContents{contents}, nil
+}
+
+// handleUsageResource handles usage resource requests
+func handleUsageResource(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return nil, ErrNoAuthToken
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	projectID := request.Params.URI[len("openai-orgs://usage/"):]
+
+	// Get all types of usage for comprehensive data
+	usageData := make(map[string]interface{})
+
+	// Get completions usage
+	completions, err := client.GetCompletionsUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["completions"] = completions
+	}
+
+	// Get embeddings usage
+	embeddings, err := client.GetEmbeddingsUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["embeddings"] = embeddings
+	}
+
+	// Get images usage
+	images, err := client.GetImagesUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["images"] = images
+	}
+
+	data, err := json.Marshal(usageData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal usage data: %w", err)
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      request.Params.URI,
+		MIMEType: MIMETypeUsage,
+		Text:     string(data),
+	}
+
+	// Handle subscription if requested
+	if sub, ok := request.Params.Arguments["subscribe"].(bool); ok && sub {
+		ch := subManager.subscribe(request.Params.URI)
+		go func() {
+			<-ctx.Done()
+			subManager.unsubscribe(request.Params.URI, ch)
+		}()
+	}
+
+	return []mcp.ResourceContents{contents}, nil
+}
+
+// pollForChanges periodically checks for changes in resources
+func pollForChanges(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Poll for changes and notify subscribers
+			checkForResourceChanges(ctx)
+		}
+	}
+}
+
+func checkForResourceChanges(ctx context.Context) {
+	// This is a simplified implementation. In production, you'd want to:
+	// 1. Keep track of last known state
+	// 2. Compare with current state
+	// 3. Only notify on actual changes
+	// 4. Handle rate limiting
+	// 5. Implement proper error handling and backoff
+
+	subManager.RLock()
+	defer subManager.RUnlock()
+
+	for uri := range subManager.subscribers {
+		// Based on URI pattern, fetch appropriate resource
+		switch {
+		case strings.HasPrefix(uri, "openai-orgs://projects/"):
+			go updateProjectResource(ctx, uri)
+		case strings.HasPrefix(uri, "openai-orgs://members/"):
+			go updateMemberResource(ctx, uri)
+		case strings.HasPrefix(uri, "openai-orgs://usage/"):
+			go updateUsageResource(ctx, uri)
+		}
+	}
+}
+
+// updateProjectResource updates a project's resource data
+func updateProjectResource(ctx context.Context, uri string) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	projectID := uri[len("openai-orgs://projects/"):]
+
+	project, err := client.RetrieveProject(projectID)
+	if err != nil {
+		return
+	}
+
+	data, err := json.Marshal(project)
+	if err != nil {
+		return
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      uri,
+		MIMEType: MIMETypeProject,
+		Text:     string(data),
+	}
+
+	subManager.notify(uri, contents)
+}
+
+// updateMemberResource updates a member's resource data
+func updateMemberResource(ctx context.Context, uri string) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	userID := uri[len("openai-orgs://members/"):]
+
+	user, err := client.RetrieveUser(userID)
+	if err != nil {
+		return
+	}
+
+	data, err := json.Marshal(user)
+	if err != nil {
+		return
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      uri,
+		MIMEType: MIMETypeMember,
+		Text:     string(data),
+	}
+
+	subManager.notify(uri, contents)
+}
+
+// updateUsageResource updates usage resource data
+func updateUsageResource(ctx context.Context, uri string) {
+	authToken := ctx.Value(authToken{}).(string)
+	if authToken == "" {
+		return
+	}
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+	projectID := uri[len("openai-orgs://usage/"):]
+
+	// Get all types of usage for comprehensive data
+	usageData := make(map[string]interface{})
+
+	// Get completions usage
+	completions, err := client.GetCompletionsUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["completions"] = completions
+	}
+
+	// Get embeddings usage
+	embeddings, err := client.GetEmbeddingsUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["embeddings"] = embeddings
+	}
+
+	// Get images usage
+	images, err := client.GetImagesUsage(map[string]string{
+		"start_time": "0",
+		"project_id": projectID,
+	})
+	if err == nil {
+		usageData["images"] = images
+	}
+
+	data, err := json.Marshal(usageData)
+	if err != nil {
+		return
+	}
+
+	contents := &mcp.TextResourceContents{
+		URI:      uri,
+		MIMEType: MIMETypeUsage,
+		Text:     string(data),
+	}
+
+	subManager.notify(uri, contents)
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -12,19 +12,15 @@ const (
 	`
 )
 
-type Server struct {
-	*server.MCPServer
-}
-
-func NewServer() (*Server, error) {
+func NewMCPServer() *server.MCPServer {
 	mcpServer := server.NewMCPServer(
 		serverName,
 		version,
 		server.WithInstructions(instructions),
 		server.WithLogging(),
-		server.WithResourceCapabilities(true, true),
-		server.WithPromptCapabilities(true),
+		server.WithToolCapabilities(true),
 	)
 
-	return &Server{mcpServer}, nil
+	AddTools(mcpServer)
+	return mcpServer
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -19,8 +19,10 @@ func NewMCPServer() *server.MCPServer {
 		server.WithInstructions(instructions),
 		server.WithLogging(),
 		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(true, true),
 	)
 
 	AddTools(mcpServer)
+	AddResources(mcpServer)
 	return mcpServer
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -24,5 +24,6 @@ func NewMCPServer() *server.MCPServer {
 
 	AddTools(mcpServer)
 	AddResources(mcpServer)
+	AddResourceTemplates(mcpServer)
 	return mcpServer
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	serverName   = "openai-orgs"
+	version      = "0.0.1"
+	instructions = `
+	You are a helpful assistant that can help with OpenAI organization management, which includes managing projects, members, limits, and billing.
+	`
+)
+
+type Server struct {
+	*server.MCPServer
+}
+
+func NewServer() (*Server, error) {
+	mcpServer := server.NewMCPServer(
+		serverName,
+		version,
+		server.WithInstructions(instructions),
+		server.WithLogging(),
+		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
+	)
+
+	return &Server{mcpServer}, nil
+}

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -1,0 +1,29 @@
+package mcp
+
+import (
+	"context"
+
+	openaiorgs "github.com/klauern/openai-orgs"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func AddTools(s *server.MCPServer) {
+	s.AddTool(mcp.NewTool(
+		"list_projects",
+		mcp.WithDescription("Lists all projects for the authenticated user"),
+	), handleListProjects)
+}
+
+func handleListProjects(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	authToken := ctx.Value(authToken{}).(string)
+
+	client := openaiorgs.NewClient(openaiorgs.DefaultBaseURL, authToken)
+
+	projects, err := client.ListProjects(100, "", false)
+	if err != nil {
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(projects.String()), nil
+}

--- a/pkg/mcp/uri.go
+++ b/pkg/mcp/uri.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	uriPrefix = "openai-orgs://"
+)
+
+// ResourceURI represents a parsed OpenAI organizations URI
+type ResourceURI struct {
+	Type           string
+	ProjectID      string
+	ServiceAccount string
+	MemberID       string
+}
+
+// ParseURI parses a raw URI string into a structured ResourceURI
+func ParseURI(uri string) (*ResourceURI, error) {
+	if !strings.HasPrefix(uri, uriPrefix) {
+		return nil, fmt.Errorf("invalid URI prefix: must start with %s", uriPrefix)
+	}
+
+	path := strings.TrimPrefix(uri, uriPrefix)
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("invalid URI: empty path")
+	}
+
+	r := &ResourceURI{
+		Type: parts[0],
+	}
+
+	switch r.Type {
+	case "project":
+		if len(parts) >= 2 {
+			r.ProjectID = parts[1]
+		}
+		if len(parts) >= 4 && parts[2] == "service-account" {
+			r.ServiceAccount = parts[3]
+		}
+	case "members":
+		if len(parts) >= 2 {
+			r.MemberID = parts[1]
+		}
+	case "active-projects", "current-members", "usage-dashboard":
+		// These are valid static resources with no additional parsing needed
+	default:
+		return nil, fmt.Errorf("invalid resource type: %s", r.Type)
+	}
+
+	return r, nil
+}
+
+// String converts the ResourceURI back to its string representation
+func (r *ResourceURI) String() string {
+	var builder strings.Builder
+	builder.WriteString(uriPrefix)
+	builder.WriteString(r.Type)
+
+	switch r.Type {
+	case "project":
+		if r.ProjectID != "" {
+			builder.WriteString("/")
+			builder.WriteString(r.ProjectID)
+			if r.ServiceAccount != "" {
+				builder.WriteString("/service-account/")
+				builder.WriteString(r.ServiceAccount)
+			}
+		}
+	case "members":
+		if r.MemberID != "" {
+			builder.WriteString("/")
+			builder.WriteString(r.MemberID)
+		}
+	}
+
+	return builder.String()
+}

--- a/project_api_keys.go
+++ b/project_api_keys.go
@@ -13,6 +13,20 @@ type ProjectApiKey struct {
 	Owner         Owner       `json:"owner"`
 }
 
+// String returns a human-readable string representation of the ProjectApiKey
+func (pak *ProjectApiKey) String() string {
+	ownerInfo := "no owner"
+	if pak.Owner.Name != "" {
+		ownerInfo = fmt.Sprintf("%s(%s)", pak.Owner.Name, pak.Owner.Type)
+	}
+	name := pak.Name
+	if name == "" {
+		name = "unnamed"
+	}
+	return fmt.Sprintf("ProjectApiKey{ID: %s, Name: %s, Owner: %s}",
+		pak.ID, name, ownerInfo)
+}
+
 func (c *Client) ListProjectApiKeys(projectID string, limit int, after string) (*ListResponse[ProjectApiKey], error) {
 	queryParams := make(map[string]string)
 	if limit > 0 {

--- a/project_rate_limits.go
+++ b/project_rate_limits.go
@@ -16,6 +16,12 @@ type ProjectRateLimit struct {
 	Batch1DayMaxInputTokens     int64  `json:"batch_1_day_max_input_tokens"`
 }
 
+// String returns a human-readable string representation of the ProjectRateLimit
+func (prl *ProjectRateLimit) String() string {
+	return fmt.Sprintf("ProjectRateLimit{ID: %s, Model: %s, MaxReq/Min: %d, MaxTokens/Min: %d}",
+		prl.ID, prl.Model, prl.MaxRequestsPer1Minute, prl.MaxTokensPer1Minute)
+}
+
 func (c *Client) ListProjectRateLimits(limit int, after string, projectId string) (*ListResponse[ProjectRateLimit], error) {
 	queryParams := make(map[string]string)
 	if limit > 0 {

--- a/project_service_accounts.go
+++ b/project_service_accounts.go
@@ -21,6 +21,16 @@ type ProjectServiceAccountAPIKey struct {
 	ID        string      `json:"id"`
 }
 
+// String returns a human-readable string representation of the ProjectServiceAccount
+func (psa *ProjectServiceAccount) String() string {
+	apiKeyInfo := "no key"
+	if psa.APIKey != nil {
+		apiKeyInfo = fmt.Sprintf("key:%s", psa.APIKey.ID)
+	}
+	return fmt.Sprintf("ProjectServiceAccount{ID: %s, Name: %s, Role: %s, APIKey: %s}",
+		psa.ID, psa.Name, psa.Role, apiKeyInfo)
+}
+
 func (c *Client) ListProjectServiceAccounts(projectID string, limit int, after string) (*ListResponse[ProjectServiceAccount], error) {
 	queryParams := make(map[string]string)
 	if limit > 0 {

--- a/project_users.go
+++ b/project_users.go
@@ -50,3 +50,9 @@ func (c *Client) ModifyProjectUser(projectID string, userID string, role string)
 func (c *Client) DeleteProjectUser(projectID string, userID string) error {
 	return Delete[ProjectUser](c.client, fmt.Sprintf(ProjectUsersListEndpoint+"/%s", projectID, userID))
 }
+
+// String returns a human-readable string representation of the ProjectUser
+func (pu *ProjectUser) String() string {
+	return fmt.Sprintf("ProjectUser{ID: %s, Name: %s, Email: %s, Role: %s}",
+		pu.ID, pu.Name, pu.Email, pu.Role)
+}

--- a/projects.go
+++ b/projects.go
@@ -45,3 +45,12 @@ func (c *Client) ModifyProject(id string, name string) (*Project, error) {
 func (c *Client) ArchiveProject(id string) (*Project, error) {
 	return Post[Project](c.client, ProjectsListEndpoint+"/"+id+"/archive", nil)
 }
+
+// String returns a human-readable string representation of the Project
+func (p *Project) String() string {
+	status := p.Status
+	if p.ArchivedAt != nil {
+		status = "archived"
+	}
+	return fmt.Sprintf("Project{ID: %s, Name: %s, Status: %s}", p.ID, p.Name, status)
+}

--- a/types.go
+++ b/types.go
@@ -1,5 +1,10 @@
 package openaiorgs
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Common response type for paginated lists
 type ListResponse[T any] struct {
 	Object  string `json:"object"`
@@ -7,6 +12,22 @@ type ListResponse[T any] struct {
 	FirstID string `json:"first_id"`
 	LastID  string `json:"last_id"`
 	HasMore bool   `json:"has_more"`
+}
+
+// String returns a pretty-printed string representation of the ListResponse
+func (lr *ListResponse[T]) String() string {
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("Object: %s\n", lr.Object))
+	result.WriteString(fmt.Sprintf("First ID: %s\n", lr.FirstID))
+	result.WriteString(fmt.Sprintf("Last ID: %s\n", lr.LastID))
+	result.WriteString(fmt.Sprintf("Has More: %v\n", lr.HasMore))
+	result.WriteString("Data:\n")
+
+	for i, item := range lr.Data {
+		result.WriteString(fmt.Sprintf("  [%d] %+v\n", i, item))
+	}
+
+	return result.String()
 }
 
 // Common owner types
@@ -43,4 +64,17 @@ func ParseRoleType(s string) RoleType {
 	default:
 		return ""
 	}
+}
+
+// String returns a human-readable string representation of the Owner
+func (o *Owner) String() string {
+	ownerInfo := "unknown"
+	switch {
+	case o.User != nil:
+		ownerInfo = fmt.Sprintf("user:%s", o.User.Email)
+	case o.SA != nil:
+		ownerInfo = fmt.Sprintf("sa:%s", o.SA.Name)
+	}
+	return fmt.Sprintf("Owner{ID: %s, Name: %s, Type: %s, Info: %s}",
+		o.ID, o.Name, o.Type, ownerInfo)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,52 @@
+package openaiorgs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListResponse_String(t *testing.T) {
+	// Create a test ListResponse with some sample data
+	response := &ListResponse[Project]{
+		Object: "list",
+		Data: []Project{
+			{
+				ID:     "proj_123",
+				Name:   "Test Project 1",
+				Status: "active",
+			},
+			{
+				ID:     "proj_456",
+				Name:   "Test Project 2",
+				Status: "archived",
+			},
+		},
+		FirstID: "proj_123",
+		LastID:  "proj_456",
+		HasMore: false,
+	}
+
+	// Get the string representation
+	result := response.String()
+
+	// Verify expected content
+	expectedParts := []string{
+		"Object: list",
+		"First ID: proj_123",
+		"Last ID: proj_456",
+		"Has More: false",
+		"Data:",
+		"[0]",
+		"proj_123",
+		"Test Project 1",
+		"[1]",
+		"proj_456",
+		"Test Project 2",
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("Expected string representation to contain %q, but it didn't.\nGot: %s", part, result)
+		}
+	}
+}

--- a/usage.go
+++ b/usage.go
@@ -374,6 +374,16 @@ type CostsUsage struct {
 	Period   string  `json:"period"`
 }
 
+// String returns a human-readable string representation of the UsageRecord
+func (ur *UsageRecord) String() string {
+	userInfo := ""
+	if ur.UserID != "" {
+		userInfo = fmt.Sprintf(", UserID: %s", ur.UserID)
+	}
+	return fmt.Sprintf("UsageRecord{ID: %s, Type: %s, Cost: %.2f, ProjectID: %s%s, Time: %s}",
+		ur.ID, ur.Type, ur.Cost, ur.ProjectID, userInfo, ur.Timestamp.Format(time.RFC3339))
+}
+
 // GetCompletionsUsage retrieves completions usage data
 //
 // Parameters:

--- a/users.go
+++ b/users.go
@@ -53,3 +53,9 @@ func (c *Client) ModifyUserRole(id string, role string) error {
 
 	return nil
 }
+
+// String returns a human-readable string representation of the User
+func (u *User) String() string {
+	return fmt.Sprintf("User{ID: %s, Name: %s, Email: %s, Role: %s}",
+		u.ID, u.Name, u.Email, u.Role)
+}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds initial support for Model Control Protocol (MCP) server functionality to the OpenAI Orgs CLI tool.

- Created a new MCP server entry point in `cmd/mcp/main.go` that initializes and serves the MCP server over stdio.
- Implemented the core MCP server in `pkg/mcp/server.go` with instructions for OpenAI organization management capabilities.
- Added the `mark3labs/mcp-go` dependency and related packages to support MCP server functionality.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

initial commit to create an MCP server for the CLI
