### PR TITLE
fix: goreleaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,8 @@ builds:
     main: ./cmd/openai-orgs/main.go
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -41,7 +42,8 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
update .goreleaser.yaml to match new deprecations
