### PR TITLE
feat: add MarshalJSON to AuditLog for proper round-trip serialization

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -26,8 +26,7 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      # This action has built-in caching for golangci-lint binary and analysis cache
+      # Combined with setup-go cache: true, this provides optimal performance
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v9.1.0
-        with:
-          # This action has built-in caching for golangci-lint binary and analysis cache
-          # Combined with setup-go cache: true, this provides optimal performance

--- a/audit_logs.go
+++ b/audit_logs.go
@@ -411,3 +411,30 @@ func (al *AuditLog) String() string {
 	return fmt.Sprintf("AuditLog{ID: %s, Type: %s, Project: %s, Actor: %s, Time: %s}",
 		al.ID, al.Type, projectInfo, actorInfo, al.EffectiveAt.String())
 }
+
+// MarshalJSON implements json.Marshaler to properly serialize the AuditLog
+// including the event-specific details under the dynamic key (e.g., "invite.deleted")
+func (al AuditLog) MarshalJSON() ([]byte, error) {
+	// Create a map to hold all fields
+	result := make(map[string]any)
+
+	// Add standard fields
+	if al.Object != "" {
+		result["object"] = al.Object
+	}
+	result["id"] = al.ID
+	result["type"] = al.Type
+	result["effective_at"] = al.EffectiveAt
+	result["actor"] = al.Actor
+
+	if al.Project != nil {
+		result["project"] = al.Project
+	}
+
+	// Add event-specific details under the dynamic key
+	if al.Details != nil && al.Type != "" {
+		result[al.Type] = al.Details
+	}
+
+	return json.Marshal(result)
+}


### PR DESCRIPTION
Add MarshalJSON method to AuditLog struct to properly serialize the event-specific details under the dynamic key (e.g., 'invite.deleted'). This enables round-trip JSON serialization without data loss.

Previously, the Details field had `json:"-"` which caused event-specific data to be lost when marshaling back to JSON.

## Changes
- Added `MarshalJSON()` method to `AuditLog` struct
- Event-specific details are now serialized under their dynamic key (e.g., `invite.deleted`, `login.succeeded`)

## Testing
- All existing tests pass
- Tested with real OpenAI audit logs API responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit log JSON serialization to properly include dynamic event-specific details based on event type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->